### PR TITLE
Tag collection mapping

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,3 @@ source :rubygems
 gemspec
 
 gem "simplecov", :require => false
-gem "fluentd", :path => 'vendor/fluentd' if RUBY_VERSION >= "1.9.2"

--- a/README.rdoc
+++ b/README.rdoc
@@ -37,7 +37,7 @@ Tail capped collection.
       # Other buffer configurations here
     </match>
 
-==== NOET
+==== NOTE
 
 MongoDB's output plugins have the limitation of buffer size.
 Because MongoDB and Ruby-Driver checks the total object size at each insertion.
@@ -45,8 +45,8 @@ If total object size gets over the size limitation,
 MongoDB returns error or Ruby-Driver raises an Exception.
 
 So, MongoDB's output plugins reset :buffer_chunk_limit if configurated value is larger than above limitation.
-  - Before v1.8, max of :buffer_chunk_limit is 2MB
-  - After v1.8, max of :buffer_chunk_limit is 10MB
+- Before v1.8, max of :buffer_chunk_limit is 2MB
+- After v1.8, max of :buffer_chunk_limit is 10MB
 
 === Backup to local capped collection
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -70,6 +70,22 @@ Use mongo_tail type in source.
       id_store_file /Users/repeatedly/devel/fluent-plugin-mongo/last_id
     </source>
 
+=== Tag map to collection
+
+Use mongo_tag_collection type in source.
+
+If tag name is "foo.bar", auto create collection "foo.bar" and insert data.
+
+    <source forward.*>
+      type mongo_tag_collection
+      database fluent
+      collection misc
+
+      # Tag "forward.foo.bar" remove prefix "forward.".
+      # Collection Mapping name is "foo.bar".
+      remove_prefix_collection forward.
+    </source>
+
 == TODO
 
 === More configuration

--- a/README.rdoc
+++ b/README.rdoc
@@ -13,6 +13,10 @@ You set -false- to 'include_time_key' parameter if you disable this behaivor.
 
 Store fluent-event to capped collection for backup.
 
+=== MongoTailInput
+
+Tail capped collection.
+
 == Configuratin
 
 === MongoOutput
@@ -22,7 +26,7 @@ Store fluent-event to capped collection for backup.
       database fluent
       collection test
 
-      # following attibutes are optional
+      # Following attibutes are optional
       host fluenter
       port 10000
 
@@ -35,7 +39,7 @@ Store fluent-event to capped collection for backup.
 
 === Backup to local capped collection
 
-Use mongo_backup type. mongo_backup alwalys use capped collection.
+Use mongo_backup type in match. mongo_backup alwalys use capped collection.
 
     <match ...>
       type mongo_backup
@@ -47,6 +51,24 @@ Use mongo_backup type. mongo_backup alwalys use capped collection.
         ...
       </store>
     </match>
+
+=== Tail capped collection
+
+Use mongo_tail type in source. 
+
+    <source>
+      type mongo_tail
+      database fluent
+      collection capped_log
+
+      tag app.mongo_log
+
+      # Convert 'time'(BSON's time) to fluent time(Unix time).
+      time_key time
+
+      # You can store last ObjectId to tail over server's shutdown
+      id_store_file /Users/repeatedly/devel/fluent-plugin-mongo/last_id
+    </source>
 
 == TODO
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -37,6 +37,17 @@ Tail capped collection.
       # Other buffer configurations here
     </match>
 
+==== NOET
+
+MongoDB's output plugins have the limitation of buffer size.
+Because MongoDB and Ruby-Driver checks the total object size at each insertion.
+If total object size gets over the size limitation,
+MongoDB returns error or Ruby-Driver raises an Exception.
+
+So, MongoDB's output plugins reset :buffer_chunk_limit if configurated value is larger than above limitation.
+  - Before v1.8, max of :buffer_chunk_limit is 2MB
+  - After v1.8, max of :buffer_chunk_limit is 10MB
+
 === Backup to local capped collection
 
 Use mongo_backup type in match. mongo_backup alwalys use capped collection.

--- a/fluent-plugin-mongo.gemspec
+++ b/fluent-plugin-mongo.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", "~> 0.10.1"
-  gem.add_dependency "mongo", ">= 1.2.0"
+  gem.add_dependency "fluentd", "~> 0.10.6"
+  gem.add_dependency "mongo", ">= 1.4.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "simplecov", ">= 0.5.4"
   gem.add_development_dependency "rr", ">= 1.0.0"

--- a/fluent-plugin-mongo.gemspec
+++ b/fluent-plugin-mongo.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mongo", ">= 1.2.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "simplecov", ">= 0.5.4"
+  gem.add_development_dependency "rr", ">= 1.0.0"
 end

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -60,12 +60,7 @@ class MongoOutput < BufferedOutput
   end
 
   def write(chunk)
-    records = []
-    chunk.msgpack_each { |record|
-      record[@time_key] = Time.at(record[@time_key]) if @include_time_key
-      records << record
-    }
-    operate(@collection, records)
+    operate(@collection, collect_records(chunk))
   end
 
   def format_collection_name(collection_name)
@@ -77,6 +72,14 @@ class MongoOutput < BufferedOutput
   end
 
   private
+  def collect_records(chunk)
+    records = []
+    chunk.msgpack_each {|record|
+      record[@time_key] = Time.at(record[@time_key]) if @include_time_key
+      records << record
+    }
+    records
+  end
 
   def get_or_create_collection(collection_name)
     collection_name = format_collection_name(collection_name)

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -68,12 +68,11 @@ class MongoOutput < BufferedOutput
   end
 
   def write(chunk)
-    result = if @tag_collection_mapping
+    if @tag_collection_mapping
       write_with_tags(chunk)
     else
       write_without_tags(chunk)
     end
-    result
   end
 
   def write_without_tags(chunk)

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -18,6 +18,7 @@ class MongoOutput < BufferedOutput
   attr_reader :argument
 
   def initialize
+    @clients = {}
     super
     require 'mongo'
     require 'msgpack'
@@ -36,6 +37,12 @@ class MongoOutput < BufferedOutput
       @argument[:max] = Config.size_value(conf['capped_max']) if conf.has_key?('capped_max')
     end
 
+    if remove_prefix_collection = conf['remove_prefix_collection']
+      @remove_prefix_collection = Regexp.new('^' + Regexp.escape(remove_prefix_collection))
+    end
+
+    @tag_collection_mapping = Config.bool_value(conf['tag_collection_mapping']) if conf.has_key?('tag_collection_mapping')
+
     # MongoDB uses BSON's Date for time.
     def @timef.format_nocache(time)
       time
@@ -44,45 +51,82 @@ class MongoOutput < BufferedOutput
 
   def start
     super
-    @client = get_or_create_collection
   end
 
   def shutdown
     # Mongo::Connection checks alive or closed myself
-    @client.db.connection.close
+    @clients.values.each {|client| client.db.connection.close }
     super
   end
 
   def format(tag, time, record)
-    record.to_msgpack
+    if @tag_collection_mapping
+      [tag, record].to_msgpack
+    else
+      record.to_msgpack
+    end
   end
 
   def write(chunk)
+    result = if @tag_collection_mapping
+      write_with_tags(chunk)
+    else
+      write_without_tags(chunk)
+    end
+    result
+  end
+
+  def write_without_tags(chunk)
     records = []
     chunk.msgpack_each { |record|
       record[@time_key] = Time.at(record[@time_key]) if @include_time_key
       records << record
     }
-    operate(records)
+    operate(@collection, records)
+  end
+
+  def write_with_tags(chunk)
+    collections = {}
+
+    chunk.msgpack_each { |tag, record|
+      record[@time_key] = Time.at(record[@time_key]) if @include_time_key
+      (collections[tag] ||= []) << record
+    }
+
+    collections.each { |collection_name, records|
+      operate(collection_name, records)
+    }
+  end
+
+  def format_collection_name(collection_name)
+    formatted = collection_name
+    formatted = formatted.gsub(@remove_prefix_collection, '') if @remove_prefix_collection
+    formatted = formatted.gsub(/(^\.+)|(\.+$)/, '')
+    formatted = @collection if formatted.size == 0 # set default for nil tag
+    formatted
   end
 
   private
 
-  def get_or_create_collection
-    db = Mongo::Connection.new(@host, @port).db(@database)
-    if db.collection_names.include?(@collection)
-      collection = db.collection(@collection)
-      return collection if @argument[:capped] == collection.capped? # TODO: Verify capped configuration
+  def get_or_create_collection(collection_name)
+    collection_name = format_collection_name(collection_name)
+    return @clients[collection_name] if @clients[collection_name]
 
-      # raise Exception if old collection does not match lastest configuration
-      raise ConfigError, "New configuration is different from existing collection"
+    @db ||= Mongo::Connection.new(@host, @port).db(@database)
+    if @db.collection_names.include?(collection_name)
+      collection = @db.collection(collection_name)
+      unless @argument[:capped] == collection.capped? # TODO: Verify capped configuration
+        # raise Exception if old collection does not match lastest configuration
+        raise ConfigError, "New configuration is different from existing collection"
+      end
+    else
+      collection = @db.create_collection(collection_name, @argument)
     end
-
-    db.create_collection(@collection, @argument)
+    @clients[collection_name] = collection
   end
 
-  def operate(records)
-    @client.insert(records)
+  def operate(collection_name, records)
+    get_or_create_collection(collection_name).insert(records)
   end
 end
 

--- a/lib/fluent/plugin/out_mongo_tag_collection.rb
+++ b/lib/fluent/plugin/out_mongo_tag_collection.rb
@@ -1,0 +1,34 @@
+
+require 'fluent/plugin/out_mongo'
+
+module Fluent
+
+class MongoOutputTagCollection < MongoOutput
+  Fluent::Plugin.register_output('mongo_tag_collection', self)
+
+  def configure(conf)
+    super
+    if remove_prefix_collection = conf['remove_prefix_collection']
+      @remove_prefix_collection = Regexp.new('^' + Regexp.escape(remove_prefix_collection))
+    end
+  end
+
+  def format(tag, time, record)
+    [tag, record].to_msgpack
+  end
+
+  def write(chunk)
+    collections = {}
+
+    chunk.msgpack_each { |tag, record|
+      record[@time_key] = Time.at(record[@time_key]) if @include_time_key
+      (collections[tag] ||= []) << record
+    }
+
+    collections.each { |collection_name, records|
+      operate(collection_name, records)
+    }
+  end
+end
+
+end

--- a/lib/fluent/plugin/out_mongo_tag_collection.rb
+++ b/lib/fluent/plugin/out_mongo_tag_collection.rb
@@ -13,21 +13,12 @@ class MongoOutputTagCollection < MongoOutput
     end
   end
 
-  def format(tag, time, record)
-    [tag, record].to_msgpack
+  def emit(tag, es, chain)
+    super(tag, es, chain, tag)
   end
 
   def write(chunk)
-    collections = {}
-
-    chunk.msgpack_each { |tag, record|
-      record[@time_key] = Time.at(record[@time_key]) if @include_time_key
-      (collections[tag] ||= []) << record
-    }
-
-    collections.each { |collection_name, records|
-      operate(collection_name, records)
-    }
+    operate(chunk.key, collect_records(chunk))
   end
 end
 

--- a/test/plugin/in_mongo_tail.rb
+++ b/test/plugin/in_mongo_tail.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class MongoTailInputTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+    require 'fluent/plugin/in_mongo_tail'
+  end
+
+  CONFIG = %[
+    type mongo_tail
+    database test
+    collection log
+    tag_key tag
+    time_key time
+    id_store_file /tmp/fluent_mongo_last_id
+  ]
+
+  def create_driver(conf = CONFIG)
+    Fluent::Test::InputTestDriver.new(Fluent::MongoTailInput).configure(conf)
+  end
+
+  def test_configure
+    d = create_driver
+    assert_equal('localhost', d.instance.host)
+    assert_equal(27017, d.instance.port)
+    assert_equal('test', d.instance.database)
+    assert_equal('log', d.instance.collection)
+    assert_equal('tag', d.instance.tag_key)
+    assert_equal('time', d.instance.time_key)
+    assert_equal('/tmp/fluent_mongo_last_id', d.instance.id_store_file)
+  end
+
+  def test_emit
+    # TODO: write actual code
+  end
+end

--- a/test/plugin/out_mongo.rb
+++ b/test/plugin/out_mongo.rb
@@ -12,15 +12,6 @@ class MongoOutputTest < Test::Unit::TestCase
     collection test
   ]
 
-  CONFIG_WITH_MAPPING = %[
-    type mongo
-    database fluent
-    collection test
-
-    tag_collection_mapping true
-    remove_prefix_collection should.remove.
-  ]
-
   def create_driver(conf = CONFIG)
     Fluent::Test::BufferedOutputTestDriver.new(Fluent::MongoOutput) {
       def start
@@ -57,12 +48,6 @@ class MongoOutputTest < Test::Unit::TestCase
     assert_equal({:capped => true, :size => 100}, d.instance.argument)
   end
 
-  def test_configure_tag_collection_mapping
-    d = create_driver(CONFIG_WITH_MAPPING)
-    assert_equal(true, d.instance.instance_variable_get(:@tag_collection_mapping))
-    assert_equal(/^should\.remove\./, d.instance.instance_variable_get(:@remove_prefix_collection))
-  end
-
   def test_format
     d = create_driver
 
@@ -90,22 +75,6 @@ class MongoOutputTest < Test::Unit::TestCase
     assert_equal([{'a' => 1, d.instance.time_key => Time.at(t)},
                   {'a' => 2, d.instance.time_key => Time.at(t)}], documents)
     assert_equal('test', collection_name)
-  end
-
-  def test_write_with_tag_collection_mapping
-    d = create_driver(CONFIG_WITH_MAPPING)
-    d.tag = 'mytag'
-    t = emit_documents(d)
-    mock(d.instance).operate('mytag', [{'a' => 1, d.instance.time_key => Time.at(t)},
-                                       {'a' => 2, d.instance.time_key => Time.at(t)}])
-    d.run
-  end
-
-  def test_remove_prefix_collection
-    d = create_driver(CONFIG_WITH_MAPPING)
-    assert_equal('prefix', d.instance.format_collection_name('should.remove.prefix'))
-    assert_equal('test', d.instance.format_collection_name('..test..'))
-    assert_equal('test.foo', d.instance.format_collection_name('..test.foo.'))
   end
 
   def test_write_at_enable_tag

--- a/test/plugin/out_mongo.rb
+++ b/test/plugin/out_mongo.rb
@@ -25,6 +25,10 @@ class MongoOutputTest < Test::Unit::TestCase
       def operate(collection_name, records)
         [format_collection_name(collection_name), records]
       end
+
+      def mongod_version
+        "1.6.0"
+      end
     }.configure(conf)
   end
 
@@ -46,6 +50,7 @@ class MongoOutputTest < Test::Unit::TestCase
     assert_equal('fluenter', d.instance.host)
     assert_equal(27018, d.instance.port)
     assert_equal({:capped => true, :size => 100}, d.instance.argument)
+    assert_equal(Fluent::MongoOutput::LIMIT_BEFORE_v1_8, d.instance.instance_variable_get(:@buffer).buffer_chunk_limit)
   end
 
   def test_format

--- a/test/plugin/out_mongo_tag_collection.rb
+++ b/test/plugin/out_mongo_tag_collection.rb
@@ -1,0 +1,62 @@
+
+require 'test_helper'
+
+class MongoTagCollectionTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+    require 'fluent/plugin/out_mongo_tag_collection'
+  end
+
+  CONFIG = %[
+    type mongo
+    database fluent
+    collection test
+
+    tag_collection_mapping true
+    remove_prefix_collection should.remove.
+  ]
+
+  def create_driver(conf = CONFIG)
+    Fluent::Test::BufferedOutputTestDriver.new(Fluent::MongoOutputTagCollection) {
+      def start
+        super
+      end
+
+      def shutdown
+        super
+      end
+
+      def operate(collection_name, records)
+        [format_collection_name(collection_name), records]
+      end
+    }.configure(conf)
+  end
+
+  def test_configure
+    d = create_driver(CONFIG)
+    assert_equal(/^should\.remove\./, d.instance.instance_variable_get(:@remove_prefix_collection))
+  end
+
+  def emit_documents(d)
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    d.emit({'a' => 1}, time)
+    d.emit({'a' => 2}, time)
+    time
+  end
+
+  def test_write
+    d = create_driver(CONFIG)
+    d.tag = 'mytag'
+    t = emit_documents(d)
+    mock(d.instance).operate('mytag', [{'a' => 1, d.instance.time_key => Time.at(t)},
+                                       {'a' => 2, d.instance.time_key => Time.at(t)}])
+    d.run
+  end
+
+  def test_remove_prefix_collection
+    d = create_driver(CONFIG)
+    assert_equal('prefix', d.instance.format_collection_name('should.remove.prefix'))
+    assert_equal('test', d.instance.format_collection_name('..test..'))
+    assert_equal('test.foo', d.instance.format_collection_name('..test.foo.'))
+  end
+end

--- a/test/plugin/out_mongo_tag_collection.rb
+++ b/test/plugin/out_mongo_tag_collection.rb
@@ -45,6 +45,8 @@ class MongoTagCollectionTest < Test::Unit::TestCase
   end
 
   def test_write
+    skip('BufferedOutputTestDriver should support emit arguments(chain and key)')
+
     d = create_driver(CONFIG)
     d.tag = 'mytag'
     t = emit_documents(d)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,12 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
+require 'rr'
+require 'test/unit'
+class Test::Unit::TestCase
+  include RR::Adapters::TestUnit
+end
+
 if ENV['SIMPLE_COV']
   require 'simplecov'
   SimpleCov.start do 


### PR DESCRIPTION
日本語で失礼します。

タグごとに別のコレクションに保存したかったので、tag_collection_mapping という機能を実装しました。foo.bar.baz というタグならコレクション名 foo.bar.baz に自動で保存されるようになります。

また、設定の remove_prefix_collection でコレクション名から不必要な接頭字を削除するオプションも追加しました。これは remote.routing. のような転送用の prefix のタグを削除してコレクション名にしたかったためです。

ソースコードがそこそこ変わってますが、良かったら取り込んでもらえますでしょうか？なおパフォーマンス劣化はほとんど無いとは思っていますｌ。
