### PR TITLE
Rescue non utf8 string / invalid key / TypeError

### DIFF
--- a/fluent-plugin-mongo.gemspec
+++ b/fluent-plugin-mongo.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "simplecov", ">= 0.5.4"
   gem.add_development_dependency "rr", ">= 1.0.0"
+  gem.add_development_dependency "bson_ext", ">= 1.4.0"
 end

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -38,7 +38,7 @@ class MongoOutput < BufferedOutput
       if key.kind_of? String
         key.gsub(/(^\$|\.)/, '_')
       else
-        key
+        safe_hash_key key.to_s
       end
     end
 
@@ -124,7 +124,7 @@ class MongoOutput < BufferedOutput
     collection = get_or_create_collection(collection_name)
     begin
       collection.insert(records)
-    rescue BSON::InvalidStringEncoding, BSON::InvalidKeyName => e
+    rescue BSON::InvalidStringEncoding, BSON::InvalidKeyName, TypeError => e
       collection.insert(SafeRecords.bson_safe(records))
     end
   end

--- a/test/plugin/out_mongo.rb
+++ b/test/plugin/out_mongo.rb
@@ -1,4 +1,7 @@
+# -*- encoding: utf-8 -*-
+
 require 'test_helper'
+require 'nkf'
 
 class MongoOutputTest < Test::Unit::TestCase
   def setup
@@ -93,5 +96,25 @@ class MongoOutputTest < Test::Unit::TestCase
     assert_equal([{'a' => 1, d.instance.tag_key => 'test'},
                   {'a' => 2, d.instance.tag_key => 'test'}], documents)
     assert_equal('test', collection_name)
+  end
+
+  def test_non_utf8_records
+    utf8 = '日本'
+    sjis = NKF.nkf('-s', utf8)
+    now = Time.now
+    records = [
+      {
+        :time => now,
+        :strings => [sjis, utf8]
+      }, {
+      }
+    ]
+    assert_equal([
+      {
+        :time => now,
+        :strings => [utf8, utf8]
+      }, {
+      }
+    ], Fluent::MongoOutput::RecordsToUTF8.to_utf8(records))
   end
 end


### PR DESCRIPTION
運用で fluentd が mongo に書き込めなくてエラーのループになってしまう箇所を対応した実装です。実装としては、もし例外が発生したら問題のありそうな key から、問題となっている key を処理してます。
- utf8 でない文字列の utf8 化 ( NKF つかってますがダサイかも… )
- $ . 文字の置換
- String で無い文字列の String 化 ( bson_ext のみ発生 )

うーん、本来は fluent-plugin-mongo でやるべきではなくて、mongo の Ruby ライブラリ本体の例外発生時を、例外を発生させて処理を途中で止めるのではなくて、例外時はログに記録するけど無視できるオプションを入れるべきな感じもする(bson のコードを読むと、範囲外のInteger だったりと、他にも例外が発生する可能性があるので…)のですが、utf8 でなかったり . が key に入ってたり、というのは構造化ロガーの key によく使われそうなのでプラグイン側でも対応しました。
