### PR TITLE
use format time argument when record to mongodb

### DIFF
--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -60,7 +60,7 @@ class MongoOutput < BufferedOutput
   end
 
   def format(tag, time, record)
-    record.to_msgpack
+    [time, record].to_msgpack
   end
 
   def write(chunk)
@@ -83,8 +83,8 @@ class MongoOutput < BufferedOutput
 
   def collect_records(chunk)
     records = []
-    chunk.msgpack_each { |record|
-      record[@time_key] = Time.at(record[@time_key]) if @include_time_key
+    chunk.msgpack_each { |time, record|
+      record[@time_key] = Time.at(time || record[@time_key]) if @include_time_key
       records << record
     }
     records

--- a/test/plugin/out_mongo.rb
+++ b/test/plugin/out_mongo.rb
@@ -59,8 +59,8 @@ class MongoOutputTest < Test::Unit::TestCase
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
     d.emit({'a' => 1}, time)
     d.emit({'a' => 2}, time)
-    d.expect_format({'a' => 1, d.instance.time_key => time}.to_msgpack)
-    d.expect_format({'a' => 2, d.instance.time_key => time}.to_msgpack)
+    d.expect_format([time, {'a' => 1, d.instance.time_key => time}].to_msgpack)
+    d.expect_format([time, {'a' => 2, d.instance.time_key => time}].to_msgpack)
 
     d.run
   end


### PR DESCRIPTION
転送元に time があった場合、その time を優先的に使います。

今は collect_records したタイミングの時刻がログに記録されてましたが、正確な転送元が発行したログの時刻を使う用になります。
