### PR TITLE
Why mongo gem version bind '1.5.2'?

### DIFF
--- a/fluent-plugin-mongo.gemspec
+++ b/fluent-plugin-mongo.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "fluentd", ">= 0.10.7"
-  gem.add_dependency "mongo", [">= 1.5.2", "<= 1.5.2"]
+  gem.add_dependency "mongo", ">= 1.5.2"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "simplecov", ">= 0.5.4"
   gem.add_development_dependency "rr", ">= 1.0.0"


### PR DESCRIPTION
I want using mongo > 1.5.2 ...
