### PR TITLE
Rollback ignore duplicate key error

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -182,20 +182,6 @@ If you want to ignore an invalid record, set _true_ to _ignore_invalid_record_ p
       ...
     </match>
 
-=== ignore_duplicate_key_error
-
-If you want to ignore duplicate key error, E11000, set _true_ to _ignore_duplicate_key_error_ parameter in match.
-
-    <match forward.*>
-      ...
-
-      # ignore duplicate key error at write operation
-      ignore_duplicate_key_error true
-
-      ...
-    </match>
-
-
 === exclude_broken_fields
 
 If you want to exclude some fields from broken data marshaling, use _exclude_broken_fields_ to specfiy the keys.

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -16,7 +16,6 @@ module Fluent
     config_param :host, :string, :default => 'localhost'
     config_param :port, :integer, :default => 27017
     config_param :ignore_invalid_record, :bool, :default => false
-    config_param :ignore_duplicate_key_error, :bool, :default => false
     config_param :disable_collection_check, :bool, :default => nil
     config_param :exclude_broken_fields, :string, :default => nil
     config_param :write_concern, :integer, :default => nil
@@ -121,8 +120,6 @@ module Fluent
         # Probably, all records of _records_ are broken...
         if e.error_code == 13066  # 13066 means "Message contains no documents"
           operate_invalid_records(collection, records) unless @ignore_invalid_record
-        elsif e.error_code == 11000 and @ignore_duplicate_key_error
-          # 11000 means "Duplicate key error", ignoring it
         else
           raise e
         end

--- a/test/plugin/out_mongo.rb
+++ b/test/plugin/out_mongo.rb
@@ -178,22 +178,6 @@ class MongoOutputTest < Test::Unit::TestCase
     assert_equal([1, 2], documents.select { |e| e.has_key?('a') }.map { |e| e['a'] }.sort)
     assert_equal(true, @db.collection(collection_name).find({Fluent::MongoOutput::BROKEN_DATA_KEY => {'$exists' => true}}).count.zero?)
   end
-
-  def test_write_with_duplicate_key_error_at_ignore
-    d = create_driver(default_config + %[
-      ignore_duplicate_key_error true
-    ])
-
-    @db.collection(collection_name).ensure_index({a: 1}, {unique: true, dropDups: true})
-    begin
-      t = emit_documents(d)
-      t = emit_documents(d)
-      d.run
-    rescue Mongo::OperationFailure => e
-      assert_not_equal(11000, e.error_code)
-    end
-
-  end
 end
 
 class MongoReplOutputTest < MongoOutputTest


### PR DESCRIPTION
Sorry I made a mistake. Ignoring the exception raised by `collection.insert(records, INSERT_ARGUMENT)` without further handling will drop the rest of records in the same chunk. Please help to roll back my commits, thanks.
#### Bug reason

What I did was rescue and ignore `E11000`, which means duplicate key error, so **out_mongo** won't keep retrying and get stuck. Taking a further look at **mongo-ruby-driver**'s code, the [`insert_documents`](https://github.com/mongodb/mongo-ruby-driver/blob/1.9.2/lib/mongo/collection.rb#L1169) method puts `documents` into a `message` and send to [`insert_batch`](https://github.com/mongodb/mongo-ruby-driver/blob/1.9.2/lib/mongo/collection.rb#L1111) to perform the insertion. `insert_batch` will raise exception as soon as it hits an `E11000` or any other error unless the option `continue_on_error` is set, and leave the rest of records un-inserted.
#### The other solution

No, so far I didn't come up with a good way to just ignore `E11000`. I will submit an issue to mongodb to ask for this feature...

Currently **out_mongo** will be blocked when there's an error which requires human interception to fix. I thought to use the `continue_on_error` flag. By setting it, `insert_documents` will append error from each `insert_batch` call into array `errors`, move on to the rest of documents, and raise `errors.last` at last. But the problem is that there might be multiple calls of `insert_batch` and therefore multiple errors, if `errors.last` is `E11000` then the rest of errors will be ignored by `out_mongo` as well. Still `documents` wrapped in the same `message` of the `insert_batch` call will be dropped.
