### PR TITLE
Use https://rubygems.org as the rubygems source.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 


### PR DESCRIPTION
Use `https://rubygems.org` as source because `source :rubygems` is deprecated.
