### PR TITLE
Add support for URL configuration

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -143,6 +143,17 @@ Use _mongo_tail_ type in source.
       id_store_file /Users/repeatedly/devel/fluent-plugin-mongo/last_id
     </source>
 
+You can also use _url_ to specify the database to connect.
+
+    <source>
+      type mongo_tail
+      url mongodb://user:password@192.168.0.13:10249,192.168.0.14:10249/database
+      collection capped_log
+      ...
+    </source>
+
+This allows the plugin to read data from a replica set.
+
 = NOTE
 
 == Broken data as a BSON

--- a/test/plugin/in_mongo_tail.rb
+++ b/test/plugin/in_mongo_tail.rb
@@ -29,6 +29,41 @@ class MongoTailInputTest < Test::Unit::TestCase
     assert_equal('time', d.instance.time_key)
     assert_equal('/tmp/fluent_mongo_last_id', d.instance.id_store_file)
   end
+  
+  def test_url_configration
+    config = %[
+    type mongo_tail
+    url mongodb://localhost:27017/test
+    collection log
+    tag_key tag
+    time_key time
+    id_store_file /tmp/fluent_mongo_last_id
+    ]
+    
+    d = create_driver(config)
+    assert_equal("mongodb://localhost:27017/test", d.instance.url)
+    assert_nil(d.instance.database)
+    assert_equal('log', d.instance.collection)
+    assert_equal('tag', d.instance.tag_key)
+    assert_equal('time', d.instance.time_key)
+    assert_equal('/tmp/fluent_mongo_last_id', d.instance.id_store_file)
+  end
+
+  def test_url_and_database_can_not_exist
+    config = %[
+    type mongo_tail
+    url mongodb://localhost:27017/test
+    database test2
+    collection log
+    tag_key tag
+    time_key time
+    id_store_file /tmp/fluent_mongo_last_id
+    ]
+
+    assert_raises Fluent::ConfigError do
+      create_driver(config)
+    end
+  end
 
   def test_emit
     # TODO: write actual code


### PR DESCRIPTION
This PR is to support specifying server connection via `mongodb://...` URL.

It will accept configuration of Mongo database as:

```
<source>
  type mongo_tail
  url mongodb://user:password@192.168.0.13:10249,192.168.0.14:10249/database
  collection capped_log
  ...
</source>
```

 Since this patch uses standard `Mongo::URIParser` class, this also makes connecting to replica set possible.