### PR TITLE
Ssl support

### DIFF
--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -29,6 +29,11 @@ module Fluent
 
     # SSL connection
     config_param :ssl, :bool, :default => false
+    config_param :ssl_cert, :string, :default => nil
+    config_param :ssl_key, :string, :default => nil
+    config_param :ssl_key_pass_phrase, :string, :default => nil
+    config_param :ssl_verify, :bool, :default => false
+    config_param :ssl_ca_cert, :string, :default => nil
 
     attr_reader :collection_options, :connection_options
 
@@ -72,7 +77,16 @@ module Fluent
 
       @connection_options[:w] = @write_concern unless @write_concern.nil?
       @connection_options[:j] = @journaled
+
       @connection_options[:ssl] = @ssl
+
+      if @ssl
+       @connection_options[:ssl_cert] = @ssl_cert
+       @connection_options[:ssl_key] = @ssl_key
+       @connection_options[:ssl_key_pass_phrase] = @ssl_key_pass_phrase
+       @connection_options[:ssl_verify] = @ssl_verify
+       @connection_options[:ssl_ca_cert] = @ssl_ca_cert
+      end
 
       # MongoDB uses BSON's Date for time.
       def @timef.format_nocache(time)

--- a/test/plugin/out_mongo.rb
+++ b/test/plugin/out_mongo.rb
@@ -79,7 +79,7 @@ class MongoOutputTest < Test::Unit::TestCase
       ssl true
     ])
 
-    assert_equal({:ssl => true, :j => false}, d.instance.connection_options)
+    assert_equal({:ssl => true, :j => false, :ssl_cert=>nil, :ssl_key=>nil, :ssl_key_pass_phrase=>nil, :ssl_verify=>false, :ssl_ca_cert=>nil}, d.instance.connection_options)
   end
 
   def test_format


### PR DESCRIPTION


This adds support of SSL Certificate authentication
Users can pass to plugin-mongo all SSL related parameters handled by MongoClient object.

ssl_cert
ssl_key
ssl_key_pass_phrase
ssl_verify
ssl_ca_cert

http://api.mongodb.org/ruby/current/Mongo/MongoClient.html#initialize-instance_method
