### PR TITLE
Do not include `RR::Adapters::TestUnit`

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,9 +3,6 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'rr'
 require 'test/unit'
-class Test::Unit::TestCase
-  include RR::Adapters::TestUnit
-end
 
 if ENV['SIMPLE_COV']
   require 'simplecov'


### PR DESCRIPTION
This suppresses following warning while running test:

    RR deprecation warning: RR now has an autohook system. You don't need to
    `include RR::Adapters::*` in your test framework's base class anymore.