### PR TITLE
Add depends for test-unit 3.0 or higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
  - 1.9.3
  - 2.0.0
  - 2.1
+ - 2.2
  - rbx
 
 before_script:

--- a/fluent-plugin-mongo.gemspec
+++ b/fluent-plugin-mongo.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "simplecov", ">= 0.5.4"
   gem.add_development_dependency "rr", ">= 1.0.0"
+  gem.add_development_dependency "test-unit", ">= 3.0.0"
 end

--- a/test/plugin/out_mongo_tag_mapped.rb
+++ b/test/plugin/out_mongo_tag_mapped.rb
@@ -50,7 +50,7 @@ class MongoTagCollectionTest < Test::Unit::TestCase
   end
 
   def test_write
-    skip('BufferedOutputTestDriver should support emit arguments(chain and key)')
+    omit('BufferedOutputTestDriver should support emit arguments(chain and key)')
 
     d = create_driver(CONFIG)
     d.tag = 'mytag'


### PR DESCRIPTION
I added development dependency for test-unit 3.0 or higher.
And I added Ruby 2.2.x job in Travis.

