### PR TITLE
Save last ObjectID to Mongo collection

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -138,9 +138,6 @@ Use _mongo_tail_ type in source.
 
       # Convert 'time'(BSON's time) to fluent time(Unix time).
       time_key time
-
-      # You can store last ObjectId to tail over server's shutdown
-      id_store_file /Users/repeatedly/devel/fluent-plugin-mongo/last_id
     </source>
 
 You can also use _url_ to specify the database to connect.
@@ -153,6 +150,24 @@ You can also use _url_ to specify the database to connect.
     </source>
 
 This allows the plugin to read data from a replica set.
+
+You can save last ObjectId to tail over server's shutdown to file.
+
+    <source>
+      ...
+
+      id_store_file /Users/repeatedly/devel/fluent-plugin-mongo/last_id
+    </source>
+
+Or Mongo collection can be used to keep last ObjectID.
+
+    <source>
+      ...
+
+      id_store_collection last_id
+    </source>
+
+Make sure the collection is capped. The plugin inserts records but does not remove at all.
 
 = NOTE
 

--- a/lib/fluent/plugin/in_mongo_tail.rb
+++ b/lib/fluent/plugin/in_mongo_tail.rb
@@ -65,7 +65,7 @@ module Fluent
     end
 
     def shutdown
-      save_last_id(@last_id)
+      save_last_id(@last_id) unless @last_id
       close_id_storage
 
       @stop = true

--- a/test/plugin/in_mongo_tail.rb
+++ b/test/plugin/in_mongo_tail.rb
@@ -13,6 +13,7 @@ class MongoTailInputTest < Test::Unit::TestCase
     tag_key tag
     time_key time
     id_store_file /tmp/fluent_mongo_last_id
+    id_store_collection test_last_id
   ]
 
   def create_driver(conf = CONFIG)
@@ -28,6 +29,7 @@ class MongoTailInputTest < Test::Unit::TestCase
     assert_equal('tag', d.instance.tag_key)
     assert_equal('time', d.instance.time_key)
     assert_equal('/tmp/fluent_mongo_last_id', d.instance.id_store_file)
+    assert_equal('test_last_id', d.instance.id_store_collection)
   end
   
   def test_url_configration


### PR DESCRIPTION
This PR is to allow to save/resume ObjectID to tail in MongoDB. This helps running the plugin on some PaaS services including Heroku.

* Introduces `last_id_collection` configuration
* Insert records to collection specified by the configuration
* Load last `last_id` from the collection on start

The collection for last_id should be capped. The plugin inserts records, but does not remove at all.