### PR TITLE
Revise mongod lifecycle

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ Bundler::GemHelper.install_tasks
 require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
+  test.libs << 'test'
   test.test_files = FileList['test/plugin/*.rb']
   test.verbose = true
 end

--- a/test/plugin/out_mongo.rb
+++ b/test/plugin/out_mongo.rb
@@ -233,18 +233,25 @@ class MongoOutputTest < Test::Unit::TestCase
 end
 
 class MongoReplOutputTest < Test::Unit::TestCase
-  include MongoTestHelper
   include MongoOutputTestCases
+
+  class << self
+    def startup
+      setup_rs
+    end
+
+    def shutdown
+      teardown_rs
+    end
+  end
 
   def setup
     Fluent::Test.setup
     require 'fluent/plugin/out_mongo_replset'
-
-    ensure_rs
   end
 
   def teardown
-    @rs.restart_killed_nodes
+    @@rs.restart_killed_nodes
     if defined?(@db) && @db
       @db.collection(collection_name).drop
       @db.connection.close
@@ -263,7 +270,7 @@ class MongoReplOutputTest < Test::Unit::TestCase
   end
 
   def create_driver(conf = default_config)
-    @db = Mongo::MongoReplicaSetClient.new(build_seeds(3), :name => @rs.name).db(MONGO_DB_DB)
+    @db = Mongo::MongoReplicaSetClient.new(build_seeds(3), :name => @@rs.name).db(MONGO_DB_DB)
     Fluent::Test::BufferedOutputTestDriver.new(Fluent::MongoOutputReplset).configure(conf)
   end
 

--- a/test/plugin/out_mongo.rb
+++ b/test/plugin/out_mongo.rb
@@ -1,61 +1,9 @@
 # -*- coding: utf-8 -*-
 require 'tools/rs_test_helper'
 
-class MongoOutputTest < Test::Unit::TestCase
-  include MongoTestHelper
-
-  def setup
-    Fluent::Test.setup
-    require 'fluent/plugin/out_mongo'
-
-    setup_mongod
-  end
-
-  def teardown
-    @db.collection(collection_name).drop
-    teardown_mongod
-  end
-
+module MongoOutputTestCases
   def collection_name
     'test'
-  end
-
-  def default_config
-    %[
-      type mongo
-      database #{MONGO_DB_DB}
-      collection #{collection_name}
-      include_time_key true # TestDriver ignore config_set_default?
-    ]
-  end
-
-  def create_driver(conf = default_config)
-    conf = conf + %[
-      port #{@@mongod_port}
-    ]
-    @db = Mongo::MongoClient.new('localhost', @@mongod_port).db(MONGO_DB_DB)
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::MongoOutput).configure(conf)
-  end
-
-  def test_configure
-    d = create_driver(%[
-      type mongo
-      database fluent_test
-      collection test_collection
-
-      capped
-      capped_size 100
-    ])
-
-    assert_equal('fluent_test', d.instance.database)
-    assert_equal('test_collection', d.instance.collection)
-    assert_equal('localhost', d.instance.host)
-    assert_equal(@@mongod_port, d.instance.port)
-    assert_equal({:capped => true, :size => 100}, d.instance.collection_options)
-    assert_equal({:ssl => false, :pool_size => 1, :j => false}, d.instance.connection_options)
-    # buffer_chunk_limit moved from configure to start
-    # I will move this test to correct space after BufferedOutputTestDriver supports start method invoking
-    # assert_equal(Fluent::MongoOutput::LIMIT_BEFORE_v1_8, d.instance.instance_variable_get(:@buffer).buffer_chunk_limit)
   end
 
   def test_configure_with_write_concern
@@ -223,7 +171,65 @@ class MongoOutputTest < Test::Unit::TestCase
   end
 end
 
-class MongoReplOutputTest < MongoOutputTest
+class MongoOutputTest < Test::Unit::TestCase
+  include MongoTestHelper
+  include MongoOutputTestCases
+
+  def setup
+    Fluent::Test.setup
+    require 'fluent/plugin/out_mongo'
+
+    setup_mongod
+  end
+
+  def teardown
+    @db.collection(collection_name).drop
+    teardown_mongod
+  end
+
+  def default_config
+    %[
+      type mongo
+      database #{MONGO_DB_DB}
+      collection #{collection_name}
+      include_time_key true # TestDriver ignore config_set_default?
+    ]
+  end
+
+  def create_driver(conf = default_config)
+    conf = conf + %[
+      port #{@@mongod_port}
+    ]
+    @db = Mongo::MongoClient.new('localhost', @@mongod_port).db(MONGO_DB_DB)
+    Fluent::Test::BufferedOutputTestDriver.new(Fluent::MongoOutput).configure(conf)
+  end
+
+  def test_configure
+    d = create_driver(%[
+      type mongo
+      database fluent_test
+      collection test_collection
+
+      capped
+      capped_size 100
+    ])
+
+    assert_equal('fluent_test', d.instance.database)
+    assert_equal('test_collection', d.instance.collection)
+    assert_equal('localhost', d.instance.host)
+    assert_equal(@@mongod_port, d.instance.port)
+    assert_equal({:capped => true, :size => 100}, d.instance.collection_options)
+    assert_equal({:ssl => false, :pool_size => 1, :j => false}, d.instance.connection_options)
+    # buffer_chunk_limit moved from configure to start
+    # I will move this test to correct space after BufferedOutputTestDriver supports start method invoking
+    # assert_equal(Fluent::MongoOutput::LIMIT_BEFORE_v1_8, d.instance.instance_variable_get(:@buffer).buffer_chunk_limit)
+  end
+end
+
+class MongoReplOutputTest < Test::Unit::TestCase
+  include MongoTestHelper
+  include MongoOutputTestCases
+
   def setup
     Fluent::Test.setup
     require 'fluent/plugin/out_mongo_replset'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,7 +34,8 @@ MONGO_DB_PATH = File.join(File.dirname(__FILE__), 'plugin', 'data')
 
 module MongoTestHelper
   def self.cleanup_mongod_env
-    system("killall mongod")
+    Process.kill "TERM", @@pid
+    Process.waitpid @@pid
     system("rm -rf #{MONGO_DB_PATH}")
   end
 

--- a/test/tools/rs_test_helper.rb
+++ b/test/tools/rs_test_helper.rb
@@ -5,13 +5,13 @@ require 'tools/repl_set_manager'
 class Test::Unit::TestCase
   # Ensure replica set is available as an instance variable and that
   # a new set is spun up for each TestCase class
-  def ensure_rs
-    unless defined?(@@current_class) and @@current_class == self.class
-      @@current_class = self.class 
-      @@rs = ReplSetManager.new
-      @@rs.start_set
-    end
-    @rs = @@rs
+  def self.setup_rs
+    @@rs = ReplSetManager.new
+    @@rs.start_set
+  end
+
+  def self.teardown_rs
+    @@rs.cleanup_set
   end
 
   # Generic code for rescuing connection failures and retrying operations.
@@ -32,7 +32,7 @@ class Test::Unit::TestCase
   def build_seeds(num_hosts)
     seeds = []
     num_hosts.times do |n|
-      seeds << "#{@rs.host}:#{@rs.ports[n]}"
+      seeds << "#{@@rs.host}:#{@@rs.ports[n]}"
     end
     seeds
   end


### PR DESCRIPTION
I tried to write tests for `MongoTailInput`, and found some difficulties.

* I don't want `killall mongod` because it also kills my mongod I'm using for my app development
* The mongod start/stop management looks broken; it does not kill mongod as expected

I did refactor mongod lifecycle management in tests.

* Extract test cases into module from `MongoOutputTest` and `MongoReplOutputTest`
* Use `TestCase.startup` and `TestCase.shutdown` to start and stop mongod
* Use `Process.kill` to stop mongod