### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 rvm:
- - 1.9.3
- - 2.0.0
  - 2.1
  - 2.2.4
  - 2.3.1
@@ -21,10 +19,4 @@ script: bundle exec rake test
 
 matrix:
   allow_failures:
-    - rvm: 1.9.3
     - rvm: ruby-head
-  exclude:
-    - rvm: 1.9.3
-      gemfile: Gemfile
-    - rvm: 2.0.0
-      gemfile: Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
 
 gemfile:
  - Gemfile
- - Gemfile.v0.12
 
 services:
   - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
  - 2.1
  - 2.2.4
  - 2.3.1
+ - 2.4.0
  - ruby-head
 
 gemfile:

--- a/Gemfile.v0.12
+++ b/Gemfile.v0.12
@@ -1,6 +1,0 @@
-source "http://rubygems.org"
-
-gem 'json', '= 1.8.3'
-gem 'fluentd', '~> 0.12.0'
-
-gemspec

--- a/fluent-plugin-mongo.gemspec
+++ b/fluent-plugin-mongo.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "simplecov", ">= 0.5.4"
   gem.add_development_dependency "rr", ">= 1.0.0"
   gem.add_development_dependency "test-unit", ">= 3.0.0"
+  gem.add_development_dependency "timecop", "~> 0.8.0"
 end

--- a/lib/fluent/plugin/in_mongo_tail.rb
+++ b/lib/fluent/plugin/in_mongo_tail.rb
@@ -5,15 +5,6 @@ module Fluent::Plugin
   class MongoTailInput < Input
     Fluent::Plugin.register_input('mongo_tail', self)
 
-    unless method_defined?(:log)
-      define_method(:log) { $log }
-    end
-
-    # Define `router` method of v0.12 to support v0.10 or earlier
-    unless method_defined?(:router)
-      define_method("router") { ::Fluent::Engine }
-    end
-
     require 'fluent/plugin/mongo_auth'
     include Fluent::MongoAuthParams
     include Fluent::MongoAuth

--- a/lib/fluent/plugin/in_mongo_tail.rb
+++ b/lib/fluent/plugin/in_mongo_tail.rb
@@ -140,7 +140,7 @@ module Fluent::Plugin
                else
                  Fluent::Engine.now
                end
-        tag = if @tag_key
+        @tag = if @tag_key
                 t = doc.delete(@tag_key)
                 t.nil? ? 'mongo.missing_tag' : t
               else
@@ -159,7 +159,7 @@ module Fluent::Plugin
         end
         es.add(time, doc)
       }
-      router.emit_stream(tag, es)
+      router.emit_stream(@tag, es)
     end
 
     def get_last_inserted_id

--- a/lib/fluent/plugin/in_mongo_tail.rb
+++ b/lib/fluent/plugin/in_mongo_tail.rb
@@ -1,14 +1,16 @@
 # coding: utf-8
+require 'mongo'
+require 'bson'
 require 'fluent/plugin/input'
+require 'fluent/plugin/mongo_auth'
+require 'fluent/plugin/logger_support'
 
 module Fluent::Plugin
   class MongoTailInput < Input
     Fluent::Plugin.register_input('mongo_tail', self)
 
-    require 'fluent/plugin/mongo_auth'
     include Fluent::MongoAuthParams
     include Fluent::MongoAuth
-    require 'fluent/plugin/logger_support'
     include Fluent::LoggerSupport
 
     desc "MongoDB database"
@@ -42,8 +44,6 @@ module Fluent::Plugin
 
     def initialize
       super
-      require 'mongo'
-      require 'bson'
 
       @client_options = {}
       @connection_options = {}

--- a/lib/fluent/plugin/in_mongo_tail.rb
+++ b/lib/fluent/plugin/in_mongo_tail.rb
@@ -1,8 +1,9 @@
-require 'fluent/input'
+# coding: utf-8
+require 'fluent/plugin/input'
 
-module Fluent
+module Fluent::Plugin
   class MongoTailInput < Input
-    Plugin.register_input('mongo_tail', self)
+    Fluent::Plugin.register_input('mongo_tail', self)
 
     unless method_defined?(:log)
       define_method(:log) { $log }
@@ -14,10 +15,10 @@ module Fluent
     end
 
     require 'fluent/plugin/mongo_auth'
-    include MongoAuthParams
-    include MongoAuth
+    include Fluent::MongoAuthParams
+    include Fluent::MongoAuth
     require 'fluent/plugin/logger_support'
-    include LoggerSupport
+    include Fluent::LoggerSupport
 
     desc "MongoDB database"
     config_param :database, :string, default: nil
@@ -61,15 +62,15 @@ module Fluent
       super
 
       if !@tag and !@tag_key
-        raise ConfigError, "'tag' or 'tag_key' option is required on mongo_tail input"
+        raise Fluent::ConfigError, "'tag' or 'tag_key' option is required on mongo_tail input"
       end
 
       if @database && @url
-        raise ConfigError, "Both 'database' and 'url' can not be set"
+        raise Fluent::ConfigError, "Both 'database' and 'url' can not be set"
       end
 
       if !@database && !@url
-        raise ConfigError, "One of 'database' or 'url' must be specified"
+        raise Fluent::ConfigError, "One of 'database' or 'url' must be specified"
       end
 
       @last_id = @id_store_file ? get_last_id : nil
@@ -148,13 +149,13 @@ module Fluent
     end
 
     def process_documents(documents)
-      es = MultiEventStream.new
+      es = Fluent::MultiEventStream.new
       documents.each {|doc|
         time = if @time_key
                  t = doc.delete(@time_key)
-                 t.nil? ? Engine.now : t.to_i
+                 t.nil? ? Fluent::Engine.now : t.to_i
                else
-                 Engine.now
+                 Fluent::Engine.now
                end
         tag = if @tag_key
                 t = doc.delete(@tag_key)

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -4,7 +4,7 @@ module Fluent::Plugin
   class MongoOutput < Output
     Fluent::Plugin.register_output('mongo', self)
 
-    helpers :event_emitter
+    helpers :event_emitter, :inject, :compat_parameters
 
     unless method_defined?(:log)
       define_method(:log) { $log }
@@ -89,6 +89,7 @@ module Fluent::Plugin
           conf['buffer_chunk_limit'] = '8m'
         end
       end
+      compat_parameters_convert(conf, :inject)
 
       super
 
@@ -154,6 +155,7 @@ module Fluent::Plugin
     end
 
     def format(tag, time, record)
+      record = inject_values_to_record(tag, time, record)
       [time, record].to_msgpack
     end
 

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -147,8 +147,7 @@ module Fluent::Plugin
     end
 
     def format(tag, time, record)
-      record = inject_values_to_record(tag, time, record)
-      [time, record].to_msgpack
+      [tag, time, record].to_msgpack
     end
 
     def formatted_to_msgpack_binary
@@ -171,7 +170,8 @@ module Fluent::Plugin
 
     def collect_records(chunk)
       records = []
-      chunk.msgpack_each {|time, record|
+      chunk.msgpack_each {|tag, time, record|
+        record = inject_values_to_record(tag, time, record)
         records << record
       }
       records

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -12,10 +12,7 @@ module Fluent::Plugin
     require 'fluent/plugin/logger_support'
     include Fluent::LoggerSupport
 
-    include Fluent::SetTagKeyMixin
     config_set_default :include_tag_key, false
-
-    include Fluent::SetTimeKeyMixin
     config_set_default :include_time_key, true
 
     desc "MongoDB database"

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -14,6 +14,8 @@ module Fluent::Plugin
     include Fluent::MongoAuth
     include Fluent::LoggerSupport
 
+    DEFAULT_BUFFER_TYPE = "memory"
+
     config_set_default :include_tag_key, false
     config_set_default :include_time_key, true
 
@@ -47,6 +49,11 @@ module Fluent::Plugin
     config_param :ssl_key_pass_phrase, :string, default: nil, secret: true
     config_param :ssl_verify, :bool, default: false
     config_param :ssl_ca_cert, :string, default: nil
+
+    config_section :buffer do
+      config_set_default :@type, DEFAULT_BUFFER_TYPE
+      config_set_default :chunk_keys, ['tag']
+    end
 
     attr_reader :client_options, :collection_options
 

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -125,11 +125,6 @@ module Fluent::Plugin
         @client_options[:ssl_ca_cert] = @ssl_ca_cert
       end
 
-      # MongoDB uses BSON's Date for time.
-      def @timef.format_nocache(time)
-        time
-      end
-
       configure_logger(@mongo_log_level)
 
       log.debug "Setup mongo configuration: mode = #{@tag_mapped ? 'tag mapped' : 'normal'}"
@@ -182,8 +177,11 @@ module Fluent::Plugin
 
     def collect_records(chunk)
       records = []
+      time_key = @inject_config.time_key
       chunk.msgpack_each {|tag, time, record|
         record = inject_values_to_record(tag, time, record)
+        # MongoDB uses BSON's Date for time.
+        record[time_key] = Time.at(time || record[time_key]) if time_key
         records << record
       }
       records

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -6,10 +6,6 @@ module Fluent::Plugin
 
     helpers :event_emitter, :inject, :compat_parameters
 
-    unless method_defined?(:log)
-      define_method(:log) { $log }
-    end
-
     require 'fluent/plugin/mongo_auth'
     include Fluent::MongoAuthParams
     include Fluent::MongoAuth

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -176,7 +176,6 @@ module Fluent::Plugin
     def collect_records(chunk)
       records = []
       chunk.msgpack_each {|time, record|
-        record[@time_key] = Time.at(time || record[@time_key]) if @include_time_key
         records << record
       }
       records

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -150,7 +150,7 @@ module Fluent::Plugin
     end
 
     def format(tag, time, record)
-      [tag, time, record].to_msgpack
+      [time, record].to_msgpack
     end
 
     def formatted_to_msgpack_binary
@@ -178,7 +178,8 @@ module Fluent::Plugin
     def collect_records(chunk)
       records = []
       time_key = @inject_config.time_key
-      chunk.msgpack_each {|tag, time, record|
+      tag = chunk.metadata.tag
+      chunk.msgpack_each {|time, record|
         record = inject_values_to_record(tag, time, record)
         # MongoDB uses BSON's Date for time.
         record[time_key] = Time.at(time || record[time_key]) if time_key

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -1,4 +1,8 @@
+require 'mongo'
+require 'msgpack'
 require 'fluent/plugin/output'
+require 'fluent/plugin/mongo_auth'
+require 'fluent/plugin/logger_support'
 
 module Fluent::Plugin
   class MongoOutput < Output
@@ -6,10 +10,8 @@ module Fluent::Plugin
 
     helpers :event_emitter, :inject, :compat_parameters
 
-    require 'fluent/plugin/mongo_auth'
     include Fluent::MongoAuthParams
     include Fluent::MongoAuth
-    require 'fluent/plugin/logger_support'
     include Fluent::LoggerSupport
 
     config_set_default :include_tag_key, false
@@ -50,9 +52,6 @@ module Fluent::Plugin
 
     def initialize
       super
-
-      require 'mongo'
-      require 'msgpack'
 
       @client_options = {}
       @collection_options = {capped: false}

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -162,6 +162,10 @@ module Fluent::Plugin
       true
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     def write(chunk)
       collection_name = extract_placeholders(@collection, chunk.metadata)
       operate(format_collection_name(collection_name), collect_records(chunk))

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -97,7 +97,8 @@ module Fluent::Plugin
       end
 
       if conf.has_key?('tag_mapped')
-        @tag_mapped = true
+        log.warn "'tag_mapped' feature is replaced with built-in config placeholder. Please consider to use 'collection ${tag}'."
+        @collection = '${tag}'
       end
       raise Fluent::ConfigError, "normal mode requires collection parameter" if !@tag_mapped and !conf.has_key?('collection')
 
@@ -162,7 +163,7 @@ module Fluent::Plugin
     end
 
     def write(chunk)
-      collection_name = @tag_mapped ? chunk.key : @collection
+      collection_name = extract_placeholders(@collection, chunk.metadata)
       operate(format_collection_name(collection_name), collect_records(chunk))
     end
 

--- a/lib/fluent/plugin/out_mongo_replset.rb
+++ b/lib/fluent/plugin/out_mongo_replset.rb
@@ -1,8 +1,8 @@
 require 'fluent/plugin/out_mongo'
 
-module Fluent
+module Fluent::Plugin
   class MongoOutputReplset < MongoOutput
-    Plugin.register_output('mongo_replset', self)
+    Fluent::Plugin.register_output('mongo_replset', self)
 
     unless method_defined?(:log)
       define_method(:log) { $log }
@@ -33,6 +33,14 @@ module Fluent
       end
 
       log.debug "Setup replica set configuration: #{conf['replica_set']}"
+    end
+
+    def format(tag, time, record)
+      [time, record].to_msgpack
+    end
+
+    def write(chunk)
+      super
     end
 
     private

--- a/lib/fluent/plugin/out_mongo_replset.rb
+++ b/lib/fluent/plugin/out_mongo_replset.rb
@@ -4,10 +4,6 @@ module Fluent::Plugin
   class MongoOutputReplset < MongoOutput
     Fluent::Plugin.register_output('mongo_replset', self)
 
-    unless method_defined?(:log)
-      define_method(:log) { $log }
-    end
-
     config_set_default :include_tag_key, false
     config_set_default :include_time_key, true
 
@@ -17,10 +13,6 @@ module Fluent::Plugin
     config_param :read, :string, :default => nil
     desc "Retry number"
     config_param :num_retries, :integer, :default => 60
-
-    unless method_defined?(:log)
-      define_method(:log) { $log }
-    end
 
     def configure(conf)
       super

--- a/lib/fluent/plugin/out_mongo_replset.rb
+++ b/lib/fluent/plugin/out_mongo_replset.rb
@@ -36,7 +36,7 @@ module Fluent::Plugin
     end
 
     def format(tag, time, record)
-      [time, record].to_msgpack
+      super
     end
 
     def write(chunk)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,10 +4,3 @@ require 'mongo'
 require 'fluent/plugin/out_mongo'
 require 'fluent/plugin/out_mongo_replset'
 require 'fluent/plugin/in_mongo_tail'
-require 'fluent/mixin' # for TimeFormatter
-
-def time_formatter(time, time_format: nil, localtime: true, timezone: true)
-  formatter = Fluent::TimeFormatter.new(time_format, localtime, timezone)
-  formatted_time = formatter.call(time)
-  formatted_time
-end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,3 +4,10 @@ require 'mongo'
 require 'fluent/plugin/out_mongo'
 require 'fluent/plugin/out_mongo_replset'
 require 'fluent/plugin/in_mongo_tail'
+require 'fluent/mixin' # for TimeFormatter
+
+def time_formatter(time, time_format: nil, localtime: true, timezone: true)
+  formatter = Fluent::TimeFormatter.new(time_format, localtime, timezone)
+  formatted_time = formatter.call(time)
+  formatted_time
+end

--- a/test/plugin/test_in_mongo_tail.rb
+++ b/test/plugin/test_in_mongo_tail.rb
@@ -1,4 +1,5 @@
 require "helper"
+require "fluent/test/driver/input"
 
 class MongoTailInputTest < Test::Unit::TestCase
   def setup
@@ -44,7 +45,7 @@ class MongoTailInputTest < Test::Unit::TestCase
   end
 
   def create_driver(conf=default_config)
-    Fluent::Test::InputTestDriver.new(Fluent::MongoTailInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::MongoTailInput).configure(conf)
   end
 
   def test_configure

--- a/test/plugin/test_out_mongo.rb
+++ b/test/plugin/test_out_mongo.rb
@@ -2,7 +2,6 @@
 require "helper"
 require "fluent/test/driver/output"
 require "fluent/test/helpers"
-require 'fluent/mixin' # for TimeFormatter
 
 class MongoOutputTest < ::Test::Unit::TestCase
   include Fluent::Test::Helpers

--- a/test/plugin/test_out_mongo.rb
+++ b/test/plugin/test_out_mongo.rb
@@ -156,8 +156,8 @@ class MongoOutputTest < ::Test::Unit::TestCase
       d.feed(time, {'a' => 1})
       d.feed(time, {'a' => 2})
     end
-    assert_equal([time, {'a' => 1, d.instance.inject_config.time_key => formatted_time}].to_msgpack, d.formatted[0])
-    assert_equal([time, {'a' => 2, d.instance.inject_config.time_key => formatted_time}].to_msgpack, d.formatted[1])
+    assert_equal(['test', time, {'a' => 1}].to_msgpack, d.formatted[0])
+    assert_equal(['test', time, {'a' => 2}].to_msgpack, d.formatted[1])
     assert_equal(2, d.formatted.size)
   end
 

--- a/test/plugin/test_out_mongo.rb
+++ b/test/plugin/test_out_mongo.rb
@@ -151,11 +151,7 @@ class MongoOutputTest < ::Test::Unit::TestCase
     d = create_driver
 
     time = event_time("2011-01-02 13:14:15 UTC")
-    time_format = false
-    localtime = true
-    timezone = true
-    formatter = Fluent::TimeFormatter.new(time_format, localtime, timezone)
-    formatted_time = formatter.call(time)
+    formatted_time = time_formatter(time)
     d.run(default_tag: 'test') do
       d.feed(time, {'a' => 1})
       d.feed(time, {'a' => 2})
@@ -171,9 +167,10 @@ class MongoOutputTest < ::Test::Unit::TestCase
       emit_documents(d)
     end
     actual_documents = get_documents
-    time = Time.parse("2011-01-02 13:14:15 UTC")
-    expected = [{'a' => 1, d.instance.time_key => time},
-                {'a' => 2, d.instance.time_key => time}]
+    time = event_time("2011-01-02 13:14:15 UTC")
+    formatted_time = time_formatter(time)
+    expected = [{'a' => 1, d.instance.time_key => formatted_time},
+                {'a' => 2, d.instance.time_key => formatted_time}]
     assert_equal(expected, actual_documents)
   end
 
@@ -204,8 +201,8 @@ class MongoOutputTest < ::Test::Unit::TestCase
       replace_dollar_in_key_with _dollar_
     ])
 
-    original_time = "2011-01-02 13:14:15 UTC"
     time = event_time("2011-01-02 13:14:15 UTC")
+    formatted_time = time_formatter(time)
     d.run(default_tag: 'test') do
       d.feed(time, {
         "foo.bar1" => {
@@ -227,7 +224,7 @@ class MongoOutputTest < ::Test::Unit::TestCase
                   {
                     "_dollar_foo$bar"=>"baz"
                   },
-                ], "time" => Time.parse(original_time)
+                ], "time" => formatted_time
                }
     assert_equal(1, documents.size)
     assert_equal(expected, documents[0])
@@ -256,9 +253,10 @@ class MongoOutputTest < ::Test::Unit::TestCase
         emit_documents(d)
       end
       actual_documents = get_documents
-      time = Time.parse("2011-01-02 13:14:15 UTC")
-      expected = [{'a' => 1, d.instance.time_key => time},
-                  {'a' => 2, d.instance.time_key => time}]
+      time = event_time("2011-01-02 13:14:15 UTC")
+      formatted_time = time_formatter(time)
+      expected = [{'a' => 1, d.instance.time_key => formatted_time},
+                  {'a' => 2, d.instance.time_key => formatted_time}]
       assert_equal(expected, actual_documents)
     end
   end

--- a/test/plugin/test_out_mongo.rb
+++ b/test/plugin/test_out_mongo.rb
@@ -156,8 +156,8 @@ class MongoOutputTest < ::Test::Unit::TestCase
       d.feed(time, {'a' => 1})
       d.feed(time, {'a' => 2})
     end
-    assert_equal([time, {'a' => 1, d.instance.time_key => formatted_time}].to_msgpack, d.formatted[0])
-    assert_equal([time, {'a' => 2, d.instance.time_key => formatted_time}].to_msgpack, d.formatted[1])
+    assert_equal([time, {'a' => 1, d.instance.inject_config.time_key => formatted_time}].to_msgpack, d.formatted[0])
+    assert_equal([time, {'a' => 2, d.instance.inject_config.time_key => formatted_time}].to_msgpack, d.formatted[1])
     assert_equal(2, d.formatted.size)
   end
 
@@ -169,8 +169,8 @@ class MongoOutputTest < ::Test::Unit::TestCase
     actual_documents = get_documents
     time = event_time("2011-01-02 13:14:15 UTC")
     formatted_time = time_formatter(time)
-    expected = [{'a' => 1, d.instance.time_key => formatted_time},
-                {'a' => 2, d.instance.time_key => formatted_time}]
+    expected = [{'a' => 1, d.instance.inject_config.time_key => formatted_time},
+                {'a' => 2, d.instance.inject_config.time_key => formatted_time}]
     assert_equal(expected, actual_documents)
   end
 
@@ -183,8 +183,8 @@ class MongoOutputTest < ::Test::Unit::TestCase
       emit_documents(d)
     end
     actual_documents = get_documents
-    expected = [{'a' => 1, d.instance.tag_key => 'test'},
-                {'a' => 2, d.instance.tag_key => 'test'}]
+    expected = [{'a' => 1, d.instance.inject_config.tag_key => 'test'},
+                {'a' => 2, d.instance.inject_config.tag_key => 'test'}]
     assert_equal(expected, actual_documents)
   end
 
@@ -255,8 +255,8 @@ class MongoOutputTest < ::Test::Unit::TestCase
       actual_documents = get_documents
       time = event_time("2011-01-02 13:14:15 UTC")
       formatted_time = time_formatter(time)
-      expected = [{'a' => 1, d.instance.time_key => formatted_time},
-                  {'a' => 2, d.instance.time_key => formatted_time}]
+      expected = [{'a' => 1, d.instance.inject_config.time_key => formatted_time},
+                  {'a' => 2, d.instance.inject_config.time_key => formatted_time}]
       assert_equal(expected, actual_documents)
     end
   end

--- a/test/plugin/test_out_mongo.rb
+++ b/test/plugin/test_out_mongo.rb
@@ -155,8 +155,8 @@ class MongoOutputTest < ::Test::Unit::TestCase
       d.feed(time, {'a' => 1})
       d.feed(time, {'a' => 2})
     end
-    assert_equal(['test', time, {'a' => 1}].to_msgpack, d.formatted[0])
-    assert_equal(['test', time, {'a' => 2}].to_msgpack, d.formatted[1])
+    assert_equal([time, {'a' => 1}].to_msgpack, d.formatted[0])
+    assert_equal([time, {'a' => 2}].to_msgpack, d.formatted[1])
     assert_equal(2, d.formatted.size)
   end
 

--- a/test/plugin/test_out_mongo.rb
+++ b/test/plugin/test_out_mongo.rb
@@ -152,7 +152,6 @@ class MongoOutputTest < ::Test::Unit::TestCase
     d = create_driver
 
     time = event_time("2011-01-02 13:14:15 UTC")
-    formatted_time = time_formatter(time)
     d.run(default_tag: 'test') do
       d.feed(time, {'a' => 1})
       d.feed(time, {'a' => 2})
@@ -169,9 +168,8 @@ class MongoOutputTest < ::Test::Unit::TestCase
     end
     actual_documents = get_documents
     time = event_time("2011-01-02 13:14:15 UTC")
-    formatted_time = time_formatter(time)
-    expected = [{'a' => 1, d.instance.inject_config.time_key => formatted_time},
-                {'a' => 2, d.instance.inject_config.time_key => formatted_time}]
+    expected = [{'a' => 1, d.instance.inject_config.time_key => Time.at(time).localtime},
+                {'a' => 2, d.instance.inject_config.time_key => Time.at(time).localtime}]
     assert_equal(expected, actual_documents)
   end
 
@@ -197,9 +195,8 @@ class MongoOutputTest < ::Test::Unit::TestCase
       end
       actual_documents = get_documents(@tag)
       time = event_time("2011-01-02 13:14:15 UTC")
-      formatted_time = time_formatter(time)
-      expected = [{'a' => 1, d.instance.inject_config.time_key => formatted_time},
-                  {'a' => 2, d.instance.inject_config.time_key => formatted_time}]
+      expected = [{'a' => 1, d.instance.inject_config.time_key => Time.at(time).localtime},
+                  {'a' => 2, d.instance.inject_config.time_key => Time.at(time).localtime}]
       assert_equal(expected, actual_documents)
     end
   end
@@ -232,7 +229,6 @@ class MongoOutputTest < ::Test::Unit::TestCase
     ])
 
     time = event_time("2011-01-02 13:14:15 UTC")
-    formatted_time = time_formatter(time)
     d.run(default_tag: 'test') do
       d.feed(time, {
         "foo.bar1" => {
@@ -254,7 +250,7 @@ class MongoOutputTest < ::Test::Unit::TestCase
                   {
                     "_dollar_foo$bar"=>"baz"
                   },
-                ], "time" => formatted_time
+                ], "time" => Time.at(time).localtime
                }
     assert_equal(1, documents.size)
     assert_equal(expected, documents[0])
@@ -284,9 +280,8 @@ class MongoOutputTest < ::Test::Unit::TestCase
       end
       actual_documents = get_documents
       time = event_time("2011-01-02 13:14:15 UTC")
-      formatted_time = time_formatter(time)
-      expected = [{'a' => 1, d.instance.inject_config.time_key => formatted_time},
-                  {'a' => 2, d.instance.inject_config.time_key => formatted_time}]
+      expected = [{'a' => 1, d.instance.inject_config.time_key => Time.at(time).localtime},
+                  {'a' => 2, d.instance.inject_config.time_key => Time.at(time).localtime}]
       assert_equal(expected, actual_documents)
     end
   end

--- a/test/plugin/test_out_mongo.rb
+++ b/test/plugin/test_out_mongo.rb
@@ -2,6 +2,7 @@
 require "helper"
 require "fluent/test/driver/output"
 require "fluent/test/helpers"
+require 'fluent/mixin' # for TimeFormatter
 
 class MongoOutputTest < ::Test::Unit::TestCase
   include Fluent::Test::Helpers
@@ -150,12 +151,17 @@ class MongoOutputTest < ::Test::Unit::TestCase
     d = create_driver
 
     time = event_time("2011-01-02 13:14:15 UTC")
+    time_format = false
+    localtime = true
+    timezone = true
+    formatter = Fluent::TimeFormatter.new(time_format, localtime, timezone)
+    formatted_time = formatter.call(time)
     d.run(default_tag: 'test') do
       d.feed(time, {'a' => 1})
       d.feed(time, {'a' => 2})
     end
-    assert_equal([time, {'a' => 1}].to_msgpack, d.formatted[0])
-    assert_equal([time, {'a' => 2}].to_msgpack, d.formatted[1])
+    assert_equal([time, {'a' => 1, d.instance.time_key => formatted_time}].to_msgpack, d.formatted[0])
+    assert_equal([time, {'a' => 2, d.instance.time_key => formatted_time}].to_msgpack, d.formatted[1])
     assert_equal(2, d.formatted.size)
   end
 

--- a/test/plugin/test_out_mongo_replset.rb
+++ b/test/plugin/test_out_mongo_replset.rb
@@ -105,13 +105,12 @@ class MongoReplsetOutputTest < ::Test::Unit::TestCase
       d = create_driver
 
       time = event_time("2011-01-02 13:14:15 UTC")
-      formatted_time = time_formatter(time)
       d.run(default_tag: 'test') do
         d.feed(time, {'a' => 1})
         d.feed(time, {'a' => 2})
       end
-      assert_equal([time, {'a' => 1, d.instance.inject_config.time_key => formatted_time}].to_msgpack, d.formatted[0])
-      assert_equal([time, {'a' => 2, d.instance.inject_config.time_key => formatted_time}].to_msgpack, d.formatted[1])
+      assert_equal(['test', time, {'a' => 1}].to_msgpack, d.formatted[0])
+      assert_equal(['test', time, {'a' => 2}].to_msgpack, d.formatted[1])
       assert_equal(2, d.formatted.size)
     end
 
@@ -122,9 +121,8 @@ class MongoReplsetOutputTest < ::Test::Unit::TestCase
       end
       actual_documents = get_documents
       time = event_time("2011-01-02 13:14:15 UTC")
-      formatted_time = time_formatter(time)
-      expected = [{'a' => 1, d.instance.inject_config.time_key => formatted_time},
-                  {'a' => 2, d.instance.inject_config.time_key => formatted_time}]
+      expected = [{'a' => 1, d.instance.inject_config.time_key => Time.at(time).localtime},
+                  {'a' => 2, d.instance.inject_config.time_key => Time.at(time).localtime}]
       assert_equal(expected, actual_documents)
     end
   end

--- a/test/plugin/test_out_mongo_replset.rb
+++ b/test/plugin/test_out_mongo_replset.rb
@@ -110,8 +110,8 @@ class MongoReplsetOutputTest < ::Test::Unit::TestCase
         d.feed(time, {'a' => 1})
         d.feed(time, {'a' => 2})
       end
-      assert_equal([time, {'a' => 1, d.instance.time_key => formatted_time}].to_msgpack, d.formatted[0])
-      assert_equal([time, {'a' => 2, d.instance.time_key => formatted_time}].to_msgpack, d.formatted[1])
+      assert_equal([time, {'a' => 1, d.instance.inject_config.time_key => formatted_time}].to_msgpack, d.formatted[0])
+      assert_equal([time, {'a' => 2, d.instance.inject_config.time_key => formatted_time}].to_msgpack, d.formatted[1])
       assert_equal(2, d.formatted.size)
     end
 
@@ -123,8 +123,8 @@ class MongoReplsetOutputTest < ::Test::Unit::TestCase
       actual_documents = get_documents
       time = event_time("2011-01-02 13:14:15 UTC")
       formatted_time = time_formatter(time)
-      expected = [{'a' => 1, d.instance.time_key => formatted_time},
-                  {'a' => 2, d.instance.time_key => formatted_time}]
+      expected = [{'a' => 1, d.instance.inject_config.time_key => formatted_time},
+                  {'a' => 2, d.instance.inject_config.time_key => formatted_time}]
       assert_equal(expected, actual_documents)
     end
   end

--- a/test/plugin/test_out_mongo_replset.rb
+++ b/test/plugin/test_out_mongo_replset.rb
@@ -95,7 +95,7 @@ class MongoReplsetOutputTest < ::Test::Unit::TestCase
     end
 
     def emit_documents(d)
-      time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+      time = event_time("2011-01-02 13:14:15 UTC")
       d.feed(time, {'a' => 1})
       d.feed(time, {'a' => 2})
       time
@@ -105,11 +105,7 @@ class MongoReplsetOutputTest < ::Test::Unit::TestCase
       d = create_driver
 
       time = event_time("2011-01-02 13:14:15 UTC")
-      time_format = false
-      localtime = true
-      timezone = true
-      formatter = Fluent::TimeFormatter.new(time_format, localtime, timezone)
-      formatted_time = formatter.call(time)
+      formatted_time = time_formatter(time)
       d.run(default_tag: 'test') do
         d.feed(time, {'a' => 1})
         d.feed(time, {'a' => 2})
@@ -125,9 +121,10 @@ class MongoReplsetOutputTest < ::Test::Unit::TestCase
         emit_documents(d)
       end
       actual_documents = get_documents
-      time = Time.parse("2011-01-02 13:14:15 UTC")
-      expected = [{'a' => 1, d.instance.time_key => time},
-                  {'a' => 2, d.instance.time_key => time}]
+      time = event_time("2011-01-02 13:14:15 UTC")
+      formatted_time = time_formatter(time)
+      expected = [{'a' => 1, d.instance.time_key => formatted_time},
+                  {'a' => 2, d.instance.time_key => formatted_time}]
       assert_equal(expected, actual_documents)
     end
   end

--- a/test/plugin/test_out_mongo_replset.rb
+++ b/test/plugin/test_out_mongo_replset.rb
@@ -109,8 +109,8 @@ class MongoReplsetOutputTest < ::Test::Unit::TestCase
         d.feed(time, {'a' => 1})
         d.feed(time, {'a' => 2})
       end
-      assert_equal(['test', time, {'a' => 1}].to_msgpack, d.formatted[0])
-      assert_equal(['test', time, {'a' => 2}].to_msgpack, d.formatted[1])
+      assert_equal([time, {'a' => 1}].to_msgpack, d.formatted[0])
+      assert_equal([time, {'a' => 2}].to_msgpack, d.formatted[1])
       assert_equal(2, d.formatted.size)
     end
 


### PR DESCRIPTION
I've tried to migrate using v0.14 API.

### Tasks

- [x] Use inject, compat_parameter helpers
- [x] Format and inject records in `#format`
- [x] Use timer, instead of using Thread.new and loop block
- [x] Add test cases for in_mongo_tail
