### PR TITLE
Fix an unclear tag_key handling

### DIFF
--- a/lib/fluent/plugin/in_mongo_tail.rb
+++ b/lib/fluent/plugin/in_mongo_tail.rb
@@ -156,7 +156,7 @@ module Fluent
                else
                  Engine.now
                end
-        tag = if @tag_key
+        @tag = if @tag_key
                 t = doc.delete(@tag_key)
                 t.nil? ? 'mongo.missing_tag' : t
               else
@@ -175,7 +175,7 @@ module Fluent
         end
         es.add(time, doc)
       }
-      router.emit_stream(tag, es)
+      router.emit_stream(@tag, es)
     end
 
     def get_last_inserted_id


### PR DESCRIPTION
Upgrading MongoDB client PR #70 uses meaningless tag handling unintentionally.
Sorry for embedding this bug.... :cold_sweat: