### PR TITLE
Follow up migrate v0.14

### DIFF
--- a/fluent-plugin-mongo.gemspec
+++ b/fluent-plugin-mongo.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]
+  gem.add_dependency "fluentd", [">= 0.14.12", "< 2"]
   gem.add_runtime_dependency "mongo", "~> 2.2.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "simplecov", ">= 0.5.4"

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -38,9 +38,11 @@ module Fluent::Plugin
 
     # tag mapping mode
     desc "Use tag_mapped mode"
-    config_param :tag_mapped, :bool, default: false
+    config_param :tag_mapped, :bool, default: false,
+                 deprecated: "use '${tag}' placeholder in collection parameter."
     desc "Remove tag prefix"
-    config_param :remove_tag_prefix, :string, default: nil
+    config_param :remove_tag_prefix, :string, default: nil,
+                 deprecated: "use @label instead for event routing."
 
     # SSL connection
     config_param :ssl, :bool, default: false


### PR DESCRIPTION
This PR follows up https://github.com/fluent/fluent-plugin-mongo/pull/81.

* Show deprecated warnings when users use deprecated parameters.
* Really depends on Fluentd v0.14.12.