### PR TITLE
Add a missing nil check for `@inject_config` instance variable

### DIFF
--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -202,7 +202,7 @@ module Fluent::Plugin
 
     def collect_records(chunk)
       records = []
-      time_key = @inject_config.time_key
+      time_key = @inject_config.time_key if @inject_config
       tag = chunk.metadata.tag
       chunk.msgpack_each {|time, record|
         record = inject_values_to_record(tag, time, record)


### PR DESCRIPTION
Because this instance variable always does not contain actual value.

Otherwise, it causes following error when using capped collection with #91 patches:

```log
2018-01-16 16:33:38 +0900 [warn]: #0 failed to flush the buffer. retry_time=0 next_retry_seconds=2018-01-16 16:33:39 +0900 chunk="562dfbf9fad0dfa5ddc32fa6f545baf5" error_class=NoMethodError error="undefined method `time_key' for nil:NilClass"
  2018-01-16 16:33:38 +0900 [warn]: #0 /Users/cosmo/GitHub/fluent-plugin-mongo/lib/fluent/plugin/out_mongo.rb:195:in `collect_records'
  2018-01-16 16:33:38 +0900 [warn]: #0 /Users/cosmo/GitHub/fluent-plugin-mongo/lib/fluent/plugin/out_mongo.rb:177:in `write'
  2018-01-16 16:33:38 +0900 [warn]: #0 /Users/cosmo/GitHub/fluent-plugin-mongo/vendor/bundle/ruby/2.5.0/gems/fluentd-1.0.2/lib/fluent/plugin/output.rb:1093:in `try_flush'
  2018-01-16 16:33:38 +0900 [warn]: #0 /Users/cosmo/GitHub/fluent-plugin-mongo/vendor/bundle/ruby/2.5.0/gems/fluentd-1.0.2/lib/fluent/plugin/output.rb:1318:in `flush_thread_run'
  2018-01-16 16:33:38 +0900 [warn]: #0 /Users/cosmo/GitHub/fluent-plugin-mongo/vendor/bundle/ruby/2.5.0/gems/fluentd-1.0.2/lib/fluent/plugin/output.rb:439:in `block (2 levels) in start'
  2018-01-16 16:33:38 +0900 [warn]: #0 /Users/cosmo/GitHub/fluent-plugin-mongo/vendor/bundle/ruby/2.5.0/gems/fluentd-1.0.2/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
2018-01-16 16:33:39 +0900 [info]: #0 shutting down output plugin type=:mongo plugin_id="object:3fd4e44dc530"
```