### PR TITLE
Update mongo client to 2.6.x

### DIFF
--- a/fluent-plugin-mongo.gemspec
+++ b/fluent-plugin-mongo.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "fluentd", [">= 0.14.12", "< 2"]
-  gem.add_runtime_dependency "mongo", "~> 2.2.0"
+  gem.add_runtime_dependency "mongo", "~> 2.6.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "simplecov", ">= 0.5.4"
   gem.add_development_dependency "rr", ">= 1.0.0"


### PR DESCRIPTION
mongodb+srv:// scheme is supported since mongo-ruby-driver v2.5.0.
ref: https://github.com/mongodb/mongo-ruby-driver/pull/898

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

related to https://github.com/fluent/fluent-plugin-mongo/issues/100.