### PR TITLE
Follow #operate method signature change. Fix #112

### DIFF
--- a/lib/fluent/plugin/out_mongo_replset.rb
+++ b/lib/fluent/plugin/out_mongo_replset.rb
@@ -35,9 +35,9 @@ module Fluent::Plugin
 
     private
 
-    def operate(client, records)
+    def operate(database, client, records)
       rescue_connection_failure do
-        super(client, records)
+        super(database, client, records)
       end
     end
 


### PR DESCRIPTION
Since #105, #operate method need 3 arguments.
This commit follows this change.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

---

To verify this fix, it needs to execute following commands:

```
$ mkdir -p /tmp/data
$ mongod --replSet "rs0" --port 27018 --dbpath=/tmp/data
```

Another terminal:

```
$ mongo --port 27018
> rs.initiate()
```

then, execute `bundle exec rake test` (Without CI=true)