### PR TITLE
Pass chunk directly instead of chunk.metadata

### DIFF
--- a/fluent-plugin-mongo.gemspec
+++ b/fluent-plugin-mongo.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", [">= 0.14.12", "< 2"]
+  gem.add_dependency "fluentd", [">= 0.14.22", "< 2"]
   gem.add_runtime_dependency "mongo", "~> 2.6.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "simplecov", ">= 0.5.4"

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -172,8 +172,8 @@ module Fluent::Plugin
     end
 
     def write(chunk)
-      collection_name = extract_placeholders(@collection, chunk.metadata)
-      database_name = extract_placeholders(@database, chunk.metadata)
+      collection_name = extract_placeholders(@collection, chunk)
+      database_name = extract_placeholders(@database, chunk)
       operate(database_name, format_collection_name(collection_name), collect_records(chunk))
     end
 


### PR DESCRIPTION
extract_placeholders should be passed `chunk` instance directly instead of `chunk.metadata`.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>