### PR TITLE
Don't handle database placholders when specifying connection_string parameter

### DIFF
--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -173,7 +173,8 @@ module Fluent::Plugin
 
     def write(chunk)
       collection_name = extract_placeholders(@collection, chunk)
-      database_name = extract_placeholders(@database, chunk)
+      # In connection_string case, we shouldn't handle extract_placeholers for @database.
+      database_name = extract_placeholders(@database, chunk) unless @connection_string
       operate(database_name, format_collection_name(collection_name), collect_records(chunk))
     end
 


### PR DESCRIPTION
Fixes #116.

I didn't notice this functionailty breakage....
If `@database` is not set and used `@connection_string`, we shouldn't try to extract `@database` placeholder. It is a pitfall.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>