### PR TITLE
Fixed connection string broken for replicaset

### DIFF
--- a/lib/fluent/plugin/in_mongo_tail.rb
+++ b/lib/fluent/plugin/in_mongo_tail.rb
@@ -121,7 +121,14 @@ module Fluent::Plugin
       @client_options[:database] = @database
       @client_options[:user] = @user if @user
       @client_options[:password] = @password if @password
-      Mongo::Client.new(["#{node_string}"], @client_options)
+      
+      if @database
+       Mongo::Client.new(["#{node_string}"], @client_options)
+      end
+
+      if @url
+       Mongo::Client.new("#{@url}")
+      end
     end
 
     def get_collection


### PR DESCRIPTION
Config

```aconf
<source>
  @type mongo_tail
  url mongodb://mongo1:27020,mongo2:27020,mongo3:27020/test?replicaSet=prod
  collection testing
  tag mongo
  id_store_file /tmp/last_id
</source>

<match mongo**>
  @type stdout
</match>
```

Error
```log
==> /var/log/td-agent/td-agent.log <==
2019-04-20 14:46:24 +0000 [info]: gem 'fluent-plugin-elasticsearch' version '3.0.1'
2019-04-20 14:46:24 +0000 [info]: gem 'fluent-plugin-kafka' version '0.8.3'
2019-04-20 14:46:24 +0000 [info]: gem 'fluent-plugin-mongo' version '1.2.2'
2019-04-20 14:46:24 +0000 [info]: gem 'fluent-plugin-record-modifier' version '1.1.0'
2019-04-20 14:46:24 +0000 [info]: gem 'fluent-plugin-rewrite-tag-filter' version '2.1.1'
2019-04-20 14:46:24 +0000 [info]: gem 'fluent-plugin-s3' version '1.1.7'
2019-04-20 14:46:24 +0000 [info]: gem 'fluent-plugin-td' version '1.0.0'
2019-04-20 14:46:24 +0000 [info]: gem 'fluent-plugin-td-monitoring' version '0.2.4'
2019-04-20 14:46:24 +0000 [info]: gem 'fluent-plugin-webhdfs' version '1.2.3'
2019-04-20 14:46:24 +0000 [info]: gem 'fluentd' version '1.3.3'
2019-04-20 14:46:24 +0000 [info]: adding match pattern="mongo.*" type="stdout"
2019-04-20 14:46:24 +0000 [info]: adding source type="mongo_tail"
2019-04-20 14:46:24 +0000 [info]: #0 starting fluentd worker pid=12447 ppid=12427 worker=0
2019-04-20 14:46:24 +0000 [error]: #0 unexpected error error_class=Mongo::Error::InvalidDatabaseName error="nil is an invalid database name. Please provide a string or symbol."
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/mongo-2.6.4/lib/mongo/database.rb:208:in `initialize'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/mongo-2.6.4/lib/mongo/client.rb:281:in `new'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/mongo-2.6.4/lib/mongo/client.rb:281:in `initialize'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-mongo-1.2.2/lib/fluent/plugin/in_mongo_tail.rb:125:in `new'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-mongo-1.2.2/lib/fluent/plugin/in_mongo_tail.rb:125:in `client'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-mongo-1.2.2/lib/fluent/plugin/in_mongo_tail.rb:131:in `get_collection'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-mongo-1.2.2/lib/fluent/plugin/in_mongo_tail.rb:86:in `start'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/root_agent.rb:165:in `block in start'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/root_agent.rb:154:in `block (2 levels) in lifecycle'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/root_agent.rb:153:in `each'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/root_agent.rb:153:in `block in lifecycle'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/root_agent.rb:140:in `each'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/root_agent.rb:140:in `lifecycle'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/root_agent.rb:164:in `start'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/engine.rb:274:in `start'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/engine.rb:219:in `run'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/supervisor.rb:799:in `run_engine'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/supervisor.rb:549:in `block in run_worker'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/supervisor.rb:724:in `main_process'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/supervisor.rb:544:in `run_worker'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/lib/fluent/command/fluentd.rb:316:in `<top (required)>'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.3.3/bin/fluentd:8:in `<top (required)>'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/bin/fluentd:23:in `load'
2019-04-20 14:46:24 +0000 [error]: #0 /opt/td-agent/embedded/bin/fluentd:23:in `<top (required)>'
2019-04-20 14:46:24 +0000 [error]: #0 /usr/sbin/td-agent:7:in `load'
2019-04-20 14:46:24 +0000 [error]: #0 /usr/sbin/td-agent:7:in `<main>'
2019-04-20 14:46:24 +0000 [error]: #0 unexpected error error_class=Mongo::Error::InvalidDatabaseName error="nil is an invalid database name. Please provide a string or symbol."
2019-04-20 14:46:24 +0000 [error]: #0 suppressed same stacktrace
```