### PR TITLE
Allow the authentication mechanism to be specified in configuration

### DIFF
--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -108,6 +108,10 @@ module Fluent::Plugin
 
       super
 
+      if @auth_mech && !Mongo::Auth::SOURCES.has_key?(@auth_mech.to_sym)
+        raise Fluent::ConfigError, Mongo::Auth::InvalidMechanism.new(@auth_mech.to_sym)
+      end
+
       if @connection_string.nil? && @database.nil?
         raise Fluent::ConfigError,  "connection_string or database parameter is required"
       end

--- a/test/plugin/test_out_mongo.rb
+++ b/test/plugin/test_out_mongo.rb
@@ -92,6 +92,22 @@ class MongoOutputTest < ::Test::Unit::TestCase
     end
   end
 
+  def test_configure_auth_mechanism
+    Mongo::Auth::SOURCES.each do |key, value|
+      conf = default_config + %[
+        auth_mech #{key}
+      ]
+      d = create_driver(conf)
+      assert_equal(key.to_s, d.instance.auth_mech)
+    end
+    assert_raise Fluent::ConfigError do
+      conf = default_config + %[
+        auth_mech invalid
+      ]
+      d = create_driver(conf)
+    end
+  end
+
   def test_configure_with_ssl
     conf = default_config + %[
       ssl true


### PR DESCRIPTION
This allows authentication other than username/password to be used (e.g.
mongodb_x509).

I could not find any contributing guidelines in the repository, so please let me know if anything should be changed.

Fixes #119 