### PR TITLE
Proposed fix for  mongo_tail replica_set incompatibility

### DIFF
--- a/lib/fluent/plugin/in_mongo_tail.rb
+++ b/lib/fluent/plugin/in_mongo_tail.rb
@@ -118,10 +118,10 @@ module Fluent::Plugin
     private
 
     def client
-      @client_options[:database] = @database
+      @client_options[:database] = @database if @database
       @client_options[:user] = @user if @user
       @client_options[:password] = @password if @password
-      Mongo::Client.new(["#{node_string}"], @client_options)
+      Mongo::Client.new(node_string, @client_options)
     end
 
     def get_collection
@@ -133,9 +133,9 @@ module Fluent::Plugin
     def node_string
       case
       when @database
-        "#{@host}:#{@port}"
+        ["#{@host}:#{@port}"]
       when @url
-        @url
+        "#{@url}"
       end
     end
 


### PR DESCRIPTION
[**Problem**]
I have been trying to use fluentD to fetch data / log from mongo DB, craft it and send to BQ.
when I am trying to use direct connection then it's working fine but the problem occurs during replica_set configuration.

FluentD was throwing the following errors:

```log
2019-04-23 17:04:24 +0800 [info]: parsing config file is succeeded path="fluent.conf"
2019-04-23 17:04:25 +0800 [info]: using configuration file: <ROOT>
  <source>
    @type mongo_tail
    url "mongodb://user:<password>@host:27017/database?replicaSet=dev"
    collection "campaign_log"
    tag "app.campaign_log.dev"
    wait_time 5
    time_key "time"
  </source>
  <match app.campaign_log.dev>
    @type stdout
  </match>
</ROOT>
2019-04-23 17:04:25 +0800 [info]: starting fluentd-1.4.2 pid=16652 ruby="2.6.0"
2019-04-23 17:04:25 +0800 [info]: spawn command to main:  cmdline=["/Users/user-imoney/.rvm/rubies/ruby-2.6.0/bin/ruby", "-Eascii-8bit:ascii-8bit", "/Users/user-imoney/.rvm/gems/ruby-2.6.0/bin/fluentd", "-c", "fluent.conf", "--under-supervisor"]
2019-04-23 17:04:25 +0800 [info]: gem 'fluent-plugin-bigquery' version '2.1.0'
2019-04-23 17:04:25 +0800 [info]: gem 'fluent-plugin-mongo' version '1.2.2'
2019-04-23 17:04:25 +0800 [info]: gem 'fluentd' version '1.4.2'
2019-04-23 17:04:25 +0800 [info]: adding match pattern="app.campaign_log.dev" type="stdout"
2019-04-23 17:04:25 +0800 [info]: adding source type="mongo_tail"
2019-04-23 17:04:25 +0800 [info]: #0 starting fluentd worker pid=16653 ppid=16652 worker=0
2019-04-23 17:04:25 +0800 [error]: #0 unexpected error error_class=Mongo::Error::InvalidDatabaseName error="nil is an invalid database name. Please provide a string or symbol."
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/mongo-2.6.4/lib/mongo/database.rb:208:in `initialize'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/mongo-2.6.4/lib/mongo/client.rb:281:in `new'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/mongo-2.6.4/lib/mongo/client.rb:281:in `initialize'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluent-plugin-mongo-1.2.2/lib/fluent/plugin/in_mongo_tail.rb:124:in `new'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluent-plugin-mongo-1.2.2/lib/fluent/plugin/in_mongo_tail.rb:124:in `client'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluent-plugin-mongo-1.2.2/lib/fluent/plugin/in_mongo_tail.rb:128:in `get_collection'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluent-plugin-mongo-1.2.2/lib/fluent/plugin/in_mongo_tail.rb:86:in `start'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/root_agent.rb:203:in `block in start'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/root_agent.rb:192:in `block (2 levels) in lifecycle'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/root_agent.rb:191:in `each'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/root_agent.rb:191:in `block in lifecycle'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/root_agent.rb:178:in `each'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/root_agent.rb:178:in `lifecycle'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/root_agent.rb:202:in `start'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/engine.rb:274:in `start'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/engine.rb:219:in `run'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/supervisor.rb:805:in `run_engine'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/supervisor.rb:549:in `block in run_worker'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/supervisor.rb:730:in `main_process'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/supervisor.rb:544:in `run_worker'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/lib/fluent/command/fluentd.rb:316:in `<top (required)>'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/rubies/ruby-2.6.0/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/rubies/ruby-2.6.0/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/gems/fluentd-1.4.2/bin/fluentd:8:in `<top (required)>'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/bin/fluentd:23:in `load'
  2019-04-23 17:04:25 +0800 [error]: #0 /Users/user-imoney/.rvm/gems/ruby-2.6.0/bin/fluentd:23:in `<main>'
```

[**Debug**]
I have been gone through the codebase & found that, 
(a) we cannot use both database & url same time.
(b) when using url, database value is set as nil & this value persist to the rest of the flow.

[**Solution**]
(a) During debugging the codebase, I found, the database credentials were not sending to client.rb in a correct format. 
(b) Also, database value should not set until the values are set from the configuration.
(c) The code must be backward compatible.

So, Please review my solution.
