### PR TITLE
Provision to specify additional date field which will be saved in mongo as date object

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -53,7 +53,7 @@ Use _mongo_ type in match.
       capped
       capped_size 100m
 
-      # Parse date string in record to date object (Optional)
+      # Parse date string in record to date object (Optional) default: nil
       # data should contain provided key with date string or javascript timestamp value
       # eg: updated_at: "2020-02-01T08:22:23.780Z" or updated_at: 1580546457010
       # NOTE: for ruby based timestamp set field = value * 1000

--- a/README.rdoc
+++ b/README.rdoc
@@ -53,6 +53,12 @@ Use _mongo_ type in match.
       capped
       capped_size 100m
 
+      # Parse date string in record to date object (Optional)
+      # data should contain provided key with date string or javascript timestamp value
+      # eg: updated_at: "2020-02-01T08:22:23.780Z" or updated_at: 1580546457010
+      # NOTE: for ruby based timestamp set field = value * 1000
+      parse_date_key updated_at
+
       # Other buffer configurations here
     </match>
 
@@ -223,7 +229,7 @@ BSON records which include '.' or start with '$' are invalid and they will be st
       ...
       # replace '.' in keys with '__dot__'
       replace_dot_in_key_with __dot__
-    
+
       # replace '$' in keys with '__dollar__'
       # Note: This replaces '$' only on first character
       replace_dollar_in_key_with __dollar__

--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -219,7 +219,7 @@ module Fluent::Plugin
               record[date_key] = Time.parse record[date_key] if record[date_key]
             end
           rescue ArgumentError
-            log.error "Failed to parse field #{@parse_date_key}. Expected valid date string value: #{record[@parse_date_key]}"
+            log.warn "Failed to parse field #{@parse_date_key}. Expected valid date integer/string value: #{record[@parse_date_key]}"
             record[date_key] = nil
           end
         end


### PR DESCRIPTION
This PR will enable to save additional fields which are valid date object but are saved as a string in mongo as the only "**time_key**" is parsed and saved as ISO date in the document. It will help to use the range operators to fetch documents by providing the date object as part of query.

**For eg**:
when record with a ```{ updated_at: Date }``` object is pushed to kafka when sending the date to mongo it is saved as normal string and not as date object so user will not be able to execute date range queries on such documents.
