### PR TITLE
Add GitHub Actions for CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,31 @@
+name: Testing on Ubuntu
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+        mongodb-version: ['4.0', '4.2', '4.4']
+        os:
+          - ubuntu-latest
+    name: Testing with Ruby ${{ matrix.ruby }} and MongoDB ${{ matrix.mongodb-version }} on ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Start MongoDB
+      uses: supercharge/mongodb-github-action@1.3.0
+      with:
+        mongodb-version: ${{ matrix.mongodb-version }}
+    - name: unit testing
+      env:
+        CI: true
+      run: |
+        gem install bundler rake
+        bundle install --jobs 4 --retry 3
+        bundle exec rake test


### PR DESCRIPTION
I defined CI tasks with MongoDB 4.0, 4.2, 4.4 and Ruby 2.4, 2.5, 2.6, 2.7 matrices.

CI result is:
https://github.com/cosmo0920/fluent-plugin-mongo/actions/runs/437111892

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>