### PR TITLE
Update GitHub actions and Upgrade to be workable with Ruby 3

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,13 +5,29 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
         mongodb-version: ['4.0', '4.2', '4.4']
         os:
           - ubuntu-latest
+        experimental: [false]
+        include:
+          - ruby: head
+            os: ubuntu-latest
+            experimental: true
+            mongodb-version: '4.0'
+          - ruby: head
+            os: ubuntu-latest
+            experimental: true
+            mongodb-version: '4.2'
+          - ruby: head
+            os: ubuntu-latest
+            experimental: true
+            mongodb-version: '4.4'
+
     name: Testing with Ruby ${{ matrix.ruby }} and MongoDB ${{ matrix.mongodb-version }} on ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/fluent-plugin-mongo.gemspec
+++ b/fluent-plugin-mongo.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "fluentd", [">= 0.14.22", "< 2"]
-  gem.add_runtime_dependency "mongo", "~> 2.6.0"
+  gem.add_runtime_dependency "mongo", "~> 2.13.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "simplecov", ">= 0.5.4"
   gem.add_development_dependency "rr", ">= 1.0.0"

--- a/fluent-plugin-mongo.gemspec
+++ b/fluent-plugin-mongo.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "simplecov", ">= 0.5.4"
   gem.add_development_dependency "rr", ">= 1.0.0"
   gem.add_development_dependency "test-unit", ">= 3.0.0"
-  gem.add_development_dependency "timecop", "~> 0.8.0"
+  gem.add_development_dependency "timecop", "~> 0.9.4"
   gem.add_development_dependency "webrick", ">= 1.7.0"
 end

--- a/fluent-plugin-mongo.gemspec
+++ b/fluent-plugin-mongo.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rr", ">= 1.0.0"
   gem.add_development_dependency "test-unit", ">= 3.0.0"
   gem.add_development_dependency "timecop", "~> 0.8.0"
+  gem.add_development_dependency "webrick", ">= 1.7.0"
 end


### PR DESCRIPTION
* Add Ruby 3.0 and ruby-head task definitions
* Drop Ruby 2.4 task definition
* Add webrick as development dependency
* Use the latest stable version of MongoDB Ruby driver. MongoDB Ruby Driver 2.6.x contains incompatible part against Ruby 3.0.