### PR TITLE
Upgrade using mongodb ruby driver

### DIFF
--- a/fluent-plugin-mongo.gemspec
+++ b/fluent-plugin-mongo.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "fluentd", [">= 0.14.22", "< 2"]
-  gem.add_runtime_dependency "mongo", "~> 2.13.0"
+  gem.add_runtime_dependency "mongo", ">= 2.15.0", "< 2.19.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "simplecov", ">= 0.5.4"
   gem.add_development_dependency "rr", ">= 1.0.0"


### PR DESCRIPTION
According to the release note, 2.15.0 is the version which supports Ruby
3.0 formerly.

https://github.com/mongodb/mongo-ruby-driver/releases/tag/v2.15.0

Signed-off-by: Takuro Ashie <ashie@clear-code.com>