### PR TITLE
docs: add Windows installation guide

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -17,6 +17,17 @@ The gem is hosted at {Rubygems.org}[http://rubygems.org]. You can install the ge
 
     $ fluent-gem install fluent-plugin-mongo
 
+=== For Windows users
+
+This plugin depends on the C extension library (such as `bson` gem) which requires a C compiler to install.
+
+If you are using Windows, you must install the {MSYS2}[https://www.msys2.org/] development toolchain before installing this plugin:
+
+1. Run the following command in your command prompt:
+    $ ridk install
+2. Select option `3` (MSYS2 and MINGW development toolchain).
+3. Once the compiler installation is complete, run the `ridk exec fluent-gem install fluent-plugin-mongo` command.
+
 = Plugins
 
 == Output plugin


### PR DESCRIPTION
Starting from bson v4.6.0, the C extension is bundled directly into the gem, which requires a C compiler for installation. This causes installation failures on Windows environments by default.

This commit updates the README to include instructions for Windows users to install the MSYS2 development toolchain via `ridk install` and run the gem installation using `ridk exec` to ensure native extensions build successfully.

Fix #180
Fix #162 
Fix #153