### PR TITLE
out_mongo: fix NoMethodError during gracefulReload

### DIFF
--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -186,7 +186,7 @@ module Fluent::Plugin
     end
 
     def shutdown
-      @client.close
+      @client&.close
       super
     end
 


### PR DESCRIPTION
When fluentd triggers `gracefulReload` via RPC, or if the plugin fails during startup (e.g., NoServerAvailable), 
the `shutdown` method can be called while `@client` is still `nil` and causes a `NoMethodError`

This PR will fix the `NoMethodError`.

Fixes #179