### PR TITLE
out_mongo: prevent infinite retry on MaxBSONSize error

### DIFF
--- a/lib/fluent/plugin/out_mongo.rb
+++ b/lib/fluent/plugin/out_mongo.rb
@@ -359,6 +359,9 @@ module Fluent::Plugin
       rescue Mongo::Error::BulkWriteError => e
         log.warn "#{records.size - e.result["n_inserted"]} documents are not inserted. Maybe these documents are invalid as a BSON."
         forget_collection(collection)
+      rescue Mongo::Error::MaxBSONSize => e
+        log.warn e
+        raise Fluent::UnrecoverableError, e
       rescue ArgumentError => e
         log.warn e
       end

--- a/test/plugin/test_out_mongo.rb
+++ b/test/plugin/test_out_mongo.rb
@@ -622,4 +622,25 @@ class MongoOutputTest < ::Test::Unit::TestCase
       assert_nil actual_documents.first['my_id']['id']
     end
   end
+
+  def test_unrecoverable_error_on_huge_document
+    d = create_driver(%[
+      @type mongo
+      database test
+      collection test_unrecoverable
+      <buffer>
+        chunk_limit_size 30m
+      </buffer>
+    ])
+
+    d.run(default_tag: 'test') do
+      time = event_time("2011-01-02 13:14:15 UTC")
+      # The document size exceeds the 16MB limit of BSON, so it should raise an UnrecoverableError.
+      d.feed(time, {'msg' => 'x' * (20 * 1024 * 1024)})
+    end
+
+    logs = d.logs.join("\n")
+    assert_match(/got unrecoverable error.*Fluent::UnrecoverableError/, logs)
+    assert_match(/MaxBSONSize/, logs)
+  end
 end


### PR DESCRIPTION
Fix #186

MongoDB has a strict 16MB limit for a single BSON document.
Currently, if it attempts to insert a chunk that exceeds this size, the MongoDB driver raises a `Mongo::Error::MaxBSONSize` exception. 

Since this specific error was not handled by the plugin, Fluentd treated it as a standard recoverable error. 
This caused Fluentd to enter an infinite retry loop for the same oversized chunk, completely clogging the buffer and blocking subsequent normal logs from being processed.