### PR TITLE
test_in_mongo_tail: fix flaky test caused by time precision

### DIFF
--- a/test/plugin/test_in_mongo_tail.rb
+++ b/test/plugin/test_in_mongo_tail.rb
@@ -77,7 +77,7 @@ class MongoTailInputTest < Test::Unit::TestCase
       options = {}
       options[:database] = database_name
       @client = ::Mongo::Client.new(["localhost:#{port}"], options)
-      @time = Time.now
+      @time = Time.at(Time.now.to_i)
       Timecop.freeze(@time)
     end
 
@@ -114,7 +114,7 @@ class MongoTailInputTest < Test::Unit::TestCase
         time_key time
       ])
       d.run(expect_records: 1, timeout: 5) do
-        @client[collection_name].insert_one({message: "test", tag: "user.defined", time: Time.at(Fluent::Engine.now)})
+        @client[collection_name].insert_one({message: "test", tag: "user.defined", time: Time.at(Fluent::Engine.now.to_i)})
       end
       events = d.events
       assert_equal "user.defined", events[0][0]


### PR DESCRIPTION
This PR will fix following flaky test:

```
===============================================================================
Failure: test_emit_with_tag_time_keys(MongoTailInputTest::TailInputTest)
/home/runner/work/fluent-plugin-mongo/fluent-plugin-mongo/test/plugin/test_in_mongo_tail.rb:121:in `test_emit_with_tag_time_keys'
     118:       end
     119:       events = d.events
     120:       assert_equal "user.defined", events[0][0]
  => 121:       assert_equal event_time(@time.to_s), events[0][1]
     122:       assert_equal "test", events[0][2]["message"]
     123:     end
     124: 
<2026-04-23 03:10:51.000000000 +0000> expected but was
<1776913852>

diff:
? 1776913852026-04-23 03:10:51.000000000 +0000
Error: <2026-04-23 03:10:51.000000000 +0000> expected but was
<1776913852>.
```

The `test_emit_with_tag_time_keys` test occasionally failed because `Time.now` contains sub-second precision (microseconds/nanoseconds). 
When this time is inserted into MongoDB, seems the BSON driver rounds it to milliseconds. 
If the sub-second value is high (e.g., .500 to .999), it rounds up to the next second, causing a 1-second mismatch during the assertion.