### PR TITLE
test_in_mongo_tail: fix flaky test

### DIFF
--- a/test/plugin/test_in_mongo_tail.rb
+++ b/test/plugin/test_in_mongo_tail.rb
@@ -77,13 +77,11 @@ class MongoTailInputTest < Test::Unit::TestCase
       options = {}
       options[:database] = database_name
       @client = ::Mongo::Client.new(["localhost:#{port}"], options)
-      @time = Time.at(Time.now.to_i)
-      Timecop.freeze(@time)
+      @time = Time.parse('2026-01-01 00:00:00 +0900')
     end
 
     def teardown_mongod
       @client[collection_name].drop
-      Timecop.return
     end
 
     def test_emit
@@ -114,7 +112,7 @@ class MongoTailInputTest < Test::Unit::TestCase
         time_key time
       ])
       d.run(expect_records: 1, timeout: 5) do
-        @client[collection_name].insert_one({message: "test", tag: "user.defined", time: Time.at(Fluent::Engine.now.to_i)})
+        @client[collection_name].insert_one({message: "test", tag: "user.defined", time: @time})
       end
       events = d.events
       assert_equal "user.defined", events[0][0]


### PR DESCRIPTION
This PR fixes a persistent flaky test in `test_in_mongo_tail.rb` related to time assertions.

Previously, the test used `Timecop.freeze` to mock the time. However, `Timecop` does not freeze `Fluent::Engine.now` (which uses an independent clock mechanism). 

I verified this by running the following code. Even though `Timecop.freeze` was called, `Fluent::Engine.now` still returned the current system time instead of the fixed timestamp:

```ruby
      @time = Time.at(Time.parse('2026-01-01 00:00:00 +0900'))
      Timecop.freeze(@time)
      p Fluent::Engine.now
      #=> 2026-04-24 16:14:48.524823551 +0900
```

Because of this, if the execution timing straddled a second boundary, the inserted time and the expected time would diverge by 1 second, causing the test to fail intermittently.